### PR TITLE
SN paired read validator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ Change Log
 ----------
 
 
+1.7.0
+=====
+`PR 23 SN paired read validator <https://github.com/smaht-dac/submitr/pull/23>`_
+
+* Adds a validator that reports if any UnalignedRead items that are paired fastqs defined in the spreadsheet (StructuredDataSet) are paired appropriately to the same FileSet item with the R2 file paired to the R1 file
+* Also checks for duplicate R1 file references in paired_with
+
+
 1.6.3
 =====
 Update dcicutils to 8.13.3.

--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -66,6 +66,17 @@
         "Will Ronchetti",
         "William Ronchetti"
       ]
+    },
+    "sgonicholson": {
+      "emails": [
+        "sgonicholson@github.com",
+        "sarah_nicholson@hms.harvard.edu"
+      ],
+      "names": [
+        "sgonicholson",
+        "sarahgonicholson",
+        "Sarah Nicholson"
+      ]
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smaht-submitr"
-version = "1.6.3"
+version = "1.7.0"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["SMaHT DAC <smhelp@hms-dbmi.atlassian.net >"]

--- a/submitr/validators/__init__.py
+++ b/submitr/validators/__init__.py
@@ -3,3 +3,4 @@
 import submitr.validators.submitted_id_validator  # noqa
 import submitr.validators.duplicate_row_validator  # noqa
 import submitr.validators.file_set_count_validator  # noqa
+import submitr.validators.paired_read_validator  # noqa

--- a/submitr/validators/paired_read_validator.py
+++ b/submitr/validators/paired_read_validator.py
@@ -62,6 +62,4 @@ def _paired_read_validator(structured_data: StructuredDataSet, **kwargs) -> None
                         f" item {submitted_id}"
                         f" property paired_with is required for R2 files"
                         f" to link the associated R1 file."
-                        f" Make sure R1 files are before paired R2 files"
-                        f" in submission spreadsheet."
                     )

--- a/submitr/validators/paired_read_validator.py
+++ b/submitr/validators/paired_read_validator.py
@@ -1,0 +1,67 @@
+from dcicutils.structured_data import StructuredDataSet
+from submitr.validators.decorators import structured_data_validator_finish_hook
+
+# Validator that reports if any UnalignedRead items that are paired fastqs defined in the spreadsheet (StructuredDataSet)
+# are paired appropriately to the same FileSet with the R2 file paired to the R1 file
+_UNALIGNED_READS_SCHEMA_NAME = "UnalignedReads"
+_FILE_SETS_PROPERTY_NAME = "file_sets"
+_READ_PAIR_NUMBER_PROPERTY_NAME = "read_pair_number"
+_PAIRED_WITH_PROPERTY_NAME = "paired_with"
+
+
+@structured_data_validator_finish_hook
+def _paired_read_validator(structured_data: StructuredDataSet, **kwargs) -> None:
+    if not isinstance(data := structured_data.data.get(_UNALIGNED_READS_SCHEMA_NAME), list):
+        return
+    for item in data:
+        if _FILE_SETS_PROPERTY_NAME in item and (
+            submitted_id := item.get("submitted_id")
+        ):
+            if _PAIRED_WITH_PROPERTY_NAME in item:
+                # paired_with is present
+                if item.get(_READ_PAIR_NUMBER_PROPERTY_NAME) != "R2":
+                    #read_pair_number is not R2
+                    structured_data.note_validation_error(
+                        f"{_UNALIGNED_READS_SCHEMA_NAME}:"
+                        f" item {submitted_id}"
+                        f" property paired_with is only for R2 files."
+                        f" File read_pair_number is"
+                        f" {item.get(_READ_PAIR_NUMBER_PROPERTY_NAME)}."
+                    )
+                if (paired_file := [
+                    paired_file_item
+                    for paired_file_item in structured_data.data.get(_UNALIGNED_READS_SCHEMA_NAME)
+                    if paired_file_item.get("submitted_id") == item.get(_PAIRED_WITH_PROPERTY_NAME)
+                ]):
+                    paired_file_set = paired_file[0].get(_FILE_SETS_PROPERTY_NAME)
+                    read_pair_number = paired_file[0].get(_READ_PAIR_NUMBER_PROPERTY_NAME)
+                    if item.get(_FILE_SETS_PROPERTY_NAME) != paired_file_set:
+                        # paired files have different file sets
+                        structured_data.note_validation_error(
+                            f"{_UNALIGNED_READS_SCHEMA_NAME}:"
+                            f" item {submitted_id}"
+                            f" paired_with file must be linked to the same FileSet."
+                            f" R2 file linked to file set {item.get(_FILE_SETS_PROPERTY_NAME)}"
+                            f" and R1 file linked to file set {paired_file_set}."
+                        )
+                    if read_pair_number != "R1":
+                        # paired file is not R1
+                        structured_data.note_validation_error(
+                            f"{_UNALIGNED_READS_SCHEMA_NAME}:"
+                            f" item {submitted_id}"
+                            f" paired_with file must have read_pair_number of R1."
+                            f" Linked file read_pair_number is"
+                            f" {read_pair_number}."
+                        )
+            else:
+                # paired_with is not present
+                if item.get(_READ_PAIR_NUMBER_PROPERTY_NAME) == "R2":
+                    #read_pair_number is R2
+                    structured_data.note_validation_error(
+                        f"{_UNALIGNED_READS_SCHEMA_NAME}:"
+                        f" item {submitted_id}"
+                        f" property paired_with is required for R2 files"
+                        f" to link the associated R1 file."
+                        f" Make sure R1 files are before paired R2 files"
+                        f" in submission spreadsheet."
+                    )

--- a/submitr/validators/paired_read_validator.py
+++ b/submitr/validators/paired_read_validator.py
@@ -3,8 +3,8 @@ from submitr.validators.decorators import structured_data_validator_finish_hook
 
 import collections
 
-# Validator that reports if any UnalignedRead items that are paired fastqs defined in 
-# the spreadsheet (StructuredDataSet) are paired appropriately to the same FileSet 
+# Validator that reports if any UnalignedRead items that are paired fastqs defined in
+# the spreadsheet (StructuredDataSet) are paired appropriately to the same FileSet
 # with the R2 file paired to the R1 file
 # Also checks for duplicate R1 file references in paired_with
 _UNALIGNED_READS_SCHEMA_NAME = "UnalignedReads"
@@ -24,7 +24,7 @@ def _paired_read_validator(structured_data: StructuredDataSet, **kwargs) -> None
             if _PAIRED_WITH_PROPERTY_NAME in item:
                 # paired_with is present
                 if item.get(_READ_PAIR_NUMBER_PROPERTY_NAME) != "R2":
-                    #read_pair_number is not R2
+                    # read_pair_number is not R2
                     structured_data.note_validation_error(
                         f"{_UNALIGNED_READS_SCHEMA_NAME}:"
                         f" item {submitted_id}"
@@ -60,7 +60,7 @@ def _paired_read_validator(structured_data: StructuredDataSet, **kwargs) -> None
             else:
                 # paired_with is not present
                 if item.get(_READ_PAIR_NUMBER_PROPERTY_NAME) == "R2":
-                    #read_pair_number is R2
+                    # read_pair_number is R2
                     structured_data.note_validation_error(
                         f"{_UNALIGNED_READS_SCHEMA_NAME}:"
                         f" item {submitted_id}"


### PR DESCRIPTION
- Adds a validator that reports if any UnalignedRead items that are paired fastqs defined in the spreadsheet (StructuredDataSet) are paired appropriately to the same FileSet item with the R2 file paired to the R1 file
- Also checks for duplicate R1 file references in `paired_with`
- Tests run with [paired_fastq_submission_tests.xlsx](https://github.com/user-attachments/files/20232198/paired_fastq_submission_tests.xlsx) using the command: `submit-metadata-bundle paired_fastq_submission_tests.xlsx --env data --ignore-orphans --validate`
- Expected output:
```
Validation results (preliminary): ERROR

- Data errors: 6
  - ERROR: UnalignedReads: item DAC_UNALIGNED-READS_TEST2_R2 property paired_with is required for R2 files to link the associated R1 file.
  - ERROR: UnalignedReads: item DAC_UNALIGNED-READS_TEST3_R1 property paired_with is only for R2 files. File read_pair_number is R1.
  - ERROR: UnalignedReads: item DAC_UNALIGNED-READS_TEST3_R1 paired_with file must have read_pair_number of R1. Linked file read_pair_number is R2.
  - ERROR: UnalignedReads: item DAC_UNALIGNED-READS_TEST4_R paired_with file must have read_pair_number of R1. Linked file read_pair_number is None.
  - ERROR: UnalignedReads: item DAC_UNALIGNED-READS_TEST5_R2 paired_with file must be linked to the same FileSet. R2 file linked to file set ['DAC_FILE-SET_SMHT015-3O-001A4_WGS'] and R1 file linked to file set ['DAC_FILE-SET_SMHT015-3Q-001A5_WGS'].
  - ERROR: UnalignedReads: the following files are referenced in paired_with by multiple R2 files. Only one reference expected: ['DAC_UNALIGNED-READS_TEST1_R1']
 ```