### PR TITLE
SN Add life history items to unreferenced list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ Change Log
 ----------
 
 
+1.7.1
+=====
+`PR 24 SN Add life history items to unreferenced list <https://github.com/smaht-dac/submitr/pull/24>`_
+
+- Add Demographic, Diagnosis, Exposure, FamilyHistory, MedicalTreatment, DeathCircumstances, and TissueCollection to `_TYPES_WHICH_ARE_ALLOWED_TO_BE_UNREFERENCED` in the unreferenced_validator
+
+
 1.7.0
 =====
 `PR 23 SN paired read validator <https://github.com/smaht-dac/submitr/pull/23>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smaht-submitr"
-version = "1.7.0"
+version = "1.7.1"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["SMaHT DAC <smhelp@hms-dbmi.atlassian.net >"]

--- a/submitr/validators/unreferenced_validator.py
+++ b/submitr/validators/unreferenced_validator.py
@@ -12,7 +12,14 @@ _TYPES_WHICH_ARE_ALLOWED_TO_BE_UNREFERENCED = [
     "SupplementaryFile",
     "TissueSample",
     "UnalignedReads",
-    "VariantCalls"
+    "VariantCalls",
+    "Demographic",
+    "Diagnosis",
+    "Exposure",
+    "FamilyHistory",
+    "MedicalTreatment",
+    "DeathCircumstances",
+    "TissueCollection"
 ]
 
 


### PR DESCRIPTION
- Add Demographic, Diagnosis, Exposure, FamilyHistory, MedicalTreatment, DeathCircumstances, and TissueCollection to `_TYPES_WHICH_ARE_ALLOWED_TO_BE_UNREFERENCED` in the `unreferenced_validator`
- Validator checks if any `submitted_id` values are created but not referenced anywhere else in the spreadsheet. For these items, this is to expected