### PR TITLE
SN External ID validators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ smaht-submitr
 Change Log
 ----------
 
+1.8.0
+=====
+`PR 25 SN External ID validators <https://github.com/smaht-dac/submitr/pull/25>`_
+
+* Add a validator for Tissue that checks that the linked Donor `external_id` is contained within the `external_id` of the Tissue (e.g. SMHT001 and SMHT001-3A)
+* Add a validator for TissueSample that checks that the linked Tissue` external_id` is contained within the `external_id` of the TissueSample (e.g. SMHT001-3A and SMHT001-3A-001A1)
+
 
 1.7.1
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smaht-submitr"
-version = "1.7.1"
+version = "1.8.0"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["SMaHT DAC <smhelp@hms-dbmi.atlassian.net >"]

--- a/submitr/validators/__init__.py
+++ b/submitr/validators/__init__.py
@@ -4,3 +4,5 @@ import submitr.validators.submitted_id_validator  # noqa
 import submitr.validators.duplicate_row_validator  # noqa
 import submitr.validators.file_set_count_validator  # noqa
 import submitr.validators.paired_read_validator  # noqa
+import submitr.validators.tissue_external_id_validator #noqa
+import submitr.validators.tissue_sample_external_id_validator #noqa

--- a/submitr/validators/__init__.py
+++ b/submitr/validators/__init__.py
@@ -4,5 +4,5 @@ import submitr.validators.submitted_id_validator  # noqa
 import submitr.validators.duplicate_row_validator  # noqa
 import submitr.validators.file_set_count_validator  # noqa
 import submitr.validators.paired_read_validator  # noqa
-import submitr.validators.tissue_external_id_validator #noqa
-import submitr.validators.tissue_sample_external_id_validator #noqa
+import submitr.validators.tissue_external_id_validator  # noqa
+import submitr.validators.tissue_sample_external_id_validator  # noqa

--- a/submitr/validators/tissue_external_id_validator.py
+++ b/submitr/validators/tissue_external_id_validator.py
@@ -4,12 +4,13 @@ from submitr.validators.decorators import structured_data_validator_finish_hook
 
 # Validator that reports if any Tissue items are linked to Donor items
 # with an external_id that does not contain the external_id of the Donor
+# if at least one of the two items is TPC-submitted
 
 _TISSUE_SCHEMA_NAME = "Tissue"
 _DONOR_PROPERTY_NAME = "donor"
 _EXTERNAL_ID_PROPERTY_NAME = "external_id"
 _DONOR_SCHEMA_NAME = "Donor"
-
+_NDRI_SUBMISSION_CENTER = "NDRI"
 
 @structured_data_validator_finish_hook
 def _tissue_external_id_validator(structured_data: StructuredDataSet, **kwargs) -> None:
@@ -19,17 +20,20 @@ def _tissue_external_id_validator(structured_data: StructuredDataSet, **kwargs) 
         if _DONOR_PROPERTY_NAME in item and (
             submitted_id := item.get("submitted_id")
         ):
+            tissue_sc = submitted_id.split('_')[0]
             if (donor_item := [
                     donor
                     for donor in structured_data.data.get(_DONOR_SCHEMA_NAME)
                     if donor.get("submitted_id") == item.get(_DONOR_PROPERTY_NAME)
             ]):
-                donor_external_id = donor_item[0].get(_EXTERNAL_ID_PROPERTY_NAME)
-                tissue_external_id = item.get(_EXTERNAL_ID_PROPERTY_NAME)
-                if tissue_external_id.split('-')[0] != donor_external_id:
-                    structured_data.note_validation_error(
-                        f"{_TISSUE_SCHEMA_NAME}:"
-                        f" item {submitted_id}"
-                        f" external_id {tissue_external_id} does not"
-                        f" match Donor external_id {donor_external_id}."
-                    )
+                donor_sc = donor_item[0].get("submitted_id","").split('_')[0]
+                if tissue_sc == _NDRI_SUBMISSION_CENTER or donor_sc == _NDRI_SUBMISSION_CENTER:
+                    donor_external_id = donor_item[0].get(_EXTERNAL_ID_PROPERTY_NAME)
+                    tissue_external_id = item.get(_EXTERNAL_ID_PROPERTY_NAME)
+                    if tissue_external_id.split('-')[0] != donor_external_id:
+                        structured_data.note_validation_error(
+                            f"{_TISSUE_SCHEMA_NAME}:"
+                            f" item {submitted_id}"
+                            f" external_id {tissue_external_id} does not"
+                            f" match Donor external_id {donor_external_id}."
+                        )

--- a/submitr/validators/tissue_external_id_validator.py
+++ b/submitr/validators/tissue_external_id_validator.py
@@ -1,0 +1,35 @@
+from dcicutils.structured_data import StructuredDataSet
+from submitr.validators.decorators import structured_data_validator_finish_hook
+
+
+# Validator that reports if any Tissue items are linked to Donor items
+# with an external_id that does not contain the external_id of the Donor
+
+_TISSUE_SCHEMA_NAME = "Tissue"
+_DONOR_PROPERTY_NAME = "donor"
+_EXTERNAL_ID_PROPERTY_NAME = "external_id"
+_DONOR_SCHEMA_NAME = "Donor"
+
+
+@structured_data_validator_finish_hook
+def _tissue_external_id_validator(structured_data: StructuredDataSet, **kwargs) -> None:
+    if not isinstance(data := structured_data.data.get(_TISSUE_SCHEMA_NAME), list):
+        return
+    for item in data:
+        if _DONOR_PROPERTY_NAME in item and (
+            submitted_id := item.get("submitted_id")
+        ):
+            if (donor_item := [
+                    donor
+                    for donor in structured_data.data.get(_DONOR_SCHEMA_NAME)
+                    if donor.get("submitted_id") == item.get(_DONOR_PROPERTY_NAME)
+            ]):
+                donor_external_id = donor_item[0].get(_EXTERNAL_ID_PROPERTY_NAME)
+                tissue_external_id = item.get(_EXTERNAL_ID_PROPERTY_NAME)
+                if tissue_external_id.split('-')[0] != donor_external_id:
+                        structured_data.note_validation_error(
+                            f"{_TISSUE_SCHEMA_NAME}:"
+                            f" item {submitted_id}"
+                            f" external_id {tissue_external_id} does not"
+                            f" match Donor external_id {donor_external_id}."
+                        )

--- a/submitr/validators/tissue_external_id_validator.py
+++ b/submitr/validators/tissue_external_id_validator.py
@@ -12,6 +12,7 @@ _EXTERNAL_ID_PROPERTY_NAME = "external_id"
 _DONOR_SCHEMA_NAME = "Donor"
 _NDRI_SUBMISSION_CENTER = "NDRI"
 
+
 @structured_data_validator_finish_hook
 def _tissue_external_id_validator(structured_data: StructuredDataSet, **kwargs) -> None:
     if not isinstance(data := structured_data.data.get(_TISSUE_SCHEMA_NAME), list):
@@ -26,7 +27,7 @@ def _tissue_external_id_validator(structured_data: StructuredDataSet, **kwargs) 
                     for donor in structured_data.data.get(_DONOR_SCHEMA_NAME)
                     if donor.get("submitted_id") == item.get(_DONOR_PROPERTY_NAME)
             ]):
-                donor_sc = donor_item[0].get("submitted_id","").split('_')[0]
+                donor_sc = donor_item[0].get("submitted_id", "").split('_')[0]
                 if tissue_sc == _NDRI_SUBMISSION_CENTER or donor_sc == _NDRI_SUBMISSION_CENTER:
                     donor_external_id = donor_item[0].get(_EXTERNAL_ID_PROPERTY_NAME)
                     tissue_external_id = item.get(_EXTERNAL_ID_PROPERTY_NAME)

--- a/submitr/validators/tissue_external_id_validator.py
+++ b/submitr/validators/tissue_external_id_validator.py
@@ -27,9 +27,9 @@ def _tissue_external_id_validator(structured_data: StructuredDataSet, **kwargs) 
                 donor_external_id = donor_item[0].get(_EXTERNAL_ID_PROPERTY_NAME)
                 tissue_external_id = item.get(_EXTERNAL_ID_PROPERTY_NAME)
                 if tissue_external_id.split('-')[0] != donor_external_id:
-                        structured_data.note_validation_error(
-                            f"{_TISSUE_SCHEMA_NAME}:"
-                            f" item {submitted_id}"
-                            f" external_id {tissue_external_id} does not"
-                            f" match Donor external_id {donor_external_id}."
-                        )
+                    structured_data.note_validation_error(
+                        f"{_TISSUE_SCHEMA_NAME}:"
+                        f" item {submitted_id}"
+                        f" external_id {tissue_external_id} does not"
+                        f" match Donor external_id {donor_external_id}."
+                    )

--- a/submitr/validators/tissue_sample_external_id_validator.py
+++ b/submitr/validators/tissue_sample_external_id_validator.py
@@ -1,0 +1,36 @@
+from dcicutils.structured_data import StructuredDataSet
+from submitr.validators.decorators import structured_data_validator_finish_hook
+
+
+# Validator that reports if any TissueSample items are linked to Tissue items
+# with an external_id that does not contain the external_id of the Tissue
+
+_TISSUE_SAMPLE_SCHEMA_NAME = "TissueSample"
+_SAMPLE_SOURCE_PROPERTY_NAME = "sample_sources"
+_EXTERNAL_ID_PROPERTY_NAME = "external_id"
+_TISSUE_SCHEMA_NAME = "Tissue"
+
+
+@structured_data_validator_finish_hook
+def _tissue_sample_external_id_validator(structured_data: StructuredDataSet, **kwargs) -> None:
+    if not isinstance(data := structured_data.data.get(_TISSUE_SAMPLE_SCHEMA_NAME), list):
+        return
+    for item in data:
+        if _SAMPLE_SOURCE_PROPERTY_NAME in item and (
+            submitted_id := item.get("submitted_id")
+        ):
+            if (tissue_items := [
+                tissue
+                for tissue in structured_data.data.get(_TISSUE_SCHEMA_NAME)
+                if tissue.get("submitted_id") in item.get(_SAMPLE_SOURCE_PROPERTY_NAME)
+            ]):
+                tissue_external_id = tissue_items[0].get(_EXTERNAL_ID_PROPERTY_NAME)
+                tissue_sample_external_id = item.get(_EXTERNAL_ID_PROPERTY_NAME)
+                if "-".join(tissue_sample_external_id.split("-")[0:2]) != tissue_external_id:
+                        structured_data.note_validation_error(
+                            f"{_TISSUE_SAMPLE_SCHEMA_NAME}:"
+                            f" item {submitted_id}"
+                            f" external_id {tissue_sample_external_id} does not"
+                            f" match {_TISSUE_SCHEMA_NAME} external_id"
+                            f" {tissue_external_id}."
+                        )

--- a/submitr/validators/tissue_sample_external_id_validator.py
+++ b/submitr/validators/tissue_sample_external_id_validator.py
@@ -27,10 +27,10 @@ def _tissue_sample_external_id_validator(structured_data: StructuredDataSet, **k
                 tissue_external_id = tissue_items[0].get(_EXTERNAL_ID_PROPERTY_NAME)
                 tissue_sample_external_id = item.get(_EXTERNAL_ID_PROPERTY_NAME)
                 if "-".join(tissue_sample_external_id.split("-")[0:2]) != tissue_external_id:
-                        structured_data.note_validation_error(
-                            f"{_TISSUE_SAMPLE_SCHEMA_NAME}:"
-                            f" item {submitted_id}"
-                            f" external_id {tissue_sample_external_id} does not"
-                            f" match {_TISSUE_SCHEMA_NAME} external_id"
-                            f" {tissue_external_id}."
-                        )
+                    structured_data.note_validation_error(
+                        f"{_TISSUE_SAMPLE_SCHEMA_NAME}:"
+                        f" item {submitted_id}"
+                        f" external_id {tissue_sample_external_id} does not"
+                        f" match {_TISSUE_SCHEMA_NAME} external_id"
+                        f" {tissue_external_id}."
+                    )

--- a/submitr/validators/tissue_sample_external_id_validator.py
+++ b/submitr/validators/tissue_sample_external_id_validator.py
@@ -27,7 +27,7 @@ def _tissue_sample_external_id_validator(structured_data: StructuredDataSet, **k
                 for tissue in structured_data.data.get(_TISSUE_SCHEMA_NAME)
                 if tissue.get("submitted_id") in item.get(_SAMPLE_SOURCE_PROPERTY_NAME)
             ]):
-                tissue_sc = tissue_items[0].get("submitted_id","").split('_')[0]
+                tissue_sc = tissue_items[0].get("submitted_id", "").split('_')[0]
                 if tissue_sample_sc == _NDRI_SUBMISSION_CENTER or tissue_sc == _NDRI_SUBMISSION_CENTER:
                     tissue_external_id = tissue_items[0].get(_EXTERNAL_ID_PROPERTY_NAME)
                     tissue_sample_external_id = item.get(_EXTERNAL_ID_PROPERTY_NAME)

--- a/submitr/validators/tissue_sample_external_id_validator.py
+++ b/submitr/validators/tissue_sample_external_id_validator.py
@@ -4,11 +4,13 @@ from submitr.validators.decorators import structured_data_validator_finish_hook
 
 # Validator that reports if any TissueSample items are linked to Tissue items
 # with an external_id that does not contain the external_id of the Tissue
+# if at least one of the two items is TPC-submitted
 
 _TISSUE_SAMPLE_SCHEMA_NAME = "TissueSample"
 _SAMPLE_SOURCE_PROPERTY_NAME = "sample_sources"
 _EXTERNAL_ID_PROPERTY_NAME = "external_id"
 _TISSUE_SCHEMA_NAME = "Tissue"
+_NDRI_SUBMISSION_CENTER = "NDRI"
 
 
 @structured_data_validator_finish_hook
@@ -19,18 +21,21 @@ def _tissue_sample_external_id_validator(structured_data: StructuredDataSet, **k
         if _SAMPLE_SOURCE_PROPERTY_NAME in item and (
             submitted_id := item.get("submitted_id")
         ):
+            tissue_sample_sc = submitted_id.split('_')[0]
             if (tissue_items := [
                 tissue
                 for tissue in structured_data.data.get(_TISSUE_SCHEMA_NAME)
                 if tissue.get("submitted_id") in item.get(_SAMPLE_SOURCE_PROPERTY_NAME)
             ]):
-                tissue_external_id = tissue_items[0].get(_EXTERNAL_ID_PROPERTY_NAME)
-                tissue_sample_external_id = item.get(_EXTERNAL_ID_PROPERTY_NAME)
-                if "-".join(tissue_sample_external_id.split("-")[0:2]) != tissue_external_id:
-                    structured_data.note_validation_error(
-                        f"{_TISSUE_SAMPLE_SCHEMA_NAME}:"
-                        f" item {submitted_id}"
-                        f" external_id {tissue_sample_external_id} does not"
-                        f" match {_TISSUE_SCHEMA_NAME} external_id"
-                        f" {tissue_external_id}."
-                    )
+                tissue_sc = tissue_items[0].get("submitted_id","").split('_')[0]
+                if tissue_sample_sc == _NDRI_SUBMISSION_CENTER or tissue_sc == _NDRI_SUBMISSION_CENTER:
+                    tissue_external_id = tissue_items[0].get(_EXTERNAL_ID_PROPERTY_NAME)
+                    tissue_sample_external_id = item.get(_EXTERNAL_ID_PROPERTY_NAME)
+                    if "-".join(tissue_sample_external_id.split("-")[0:2]) != tissue_external_id:
+                        structured_data.note_validation_error(
+                            f"{_TISSUE_SAMPLE_SCHEMA_NAME}:"
+                            f" item {submitted_id}"
+                            f" external_id {tissue_sample_external_id} does not"
+                            f" match {_TISSUE_SCHEMA_NAME} external_id"
+                            f" {tissue_external_id}."
+                        )


### PR DESCRIPTION
- Add a validator for Tissue that checks that the linked Donor `external_id` is contained within the `external_id` of the Tissue (e.g. SMHT001 and SMHT001-3A)
- Add a validator for TissueSample that checks that the linked Tissue `external_id` is contained within the `external_id` of the TissueSample (e.g. SMHT001-3A and SMHT001-3A-001A1)
- The checks are only applied if at least one of the two items is TPC-submitted (NDRI submission center)

- NOTE: Currently can only perform the check if both items checked  (Donor and Tissue or Tissue and TissueSample) are present in the spreadsheet as their own item rows (e.g. a TissueSample item that references a Tissue item that is already present on the portal but is not in the Tissue sheet will not be checked here, *but will be at the actual patching through a custom validator*).
- Tested with 
[test_external_id_validator.xlsx](https://github.com/user-attachments/files/20953510/test_external_id_validator.xlsx) using the command `submit-metadata-bundle test_external_id_submission.xlsx --env data --ignore-orphans --submission-center ndri_tpc  --validate`
- Expected output:
```
Validation results (preliminary): ERROR

- Data errors: 4
  - ERROR: Tissue: item NDRI_TISSUE_TEST_LUNG_1 external_id SMHT035-3Q does not match Donor external_id SMHT040.
  - ERROR: Tissue: item NDRI_TISSUE_TEST_AORTA_2 external_id SMHT040-3O does not match Donor external_id ALT1.
  - ERROR: TissueSample: item NDRI_TISSUE-SAMPLE_TEST_1 external_id SMHT040-3Q-001B1 does not match Tissue external_id SMHT040-3O.
  - ERROR: TissueSample: item NDRI_TISSUE-SAMPLE_TEST_3 external_id ALT1-2 does not match Tissue external_id SMHT040-3O.

Exiting with preliminary validation errors.
```