### PR TITLE
SN Add RIN required validator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 =====
 `PR 27 SN Add RIN required validator <https://github.com/smaht-dac/submitr/pull/27>`_
 
-* Add a validator that ensures that the property rna_integrity_number has a value for Analyte items where "RNA" is in molecule
+* Add a validator that ensures that the property rna_integrity_number has a value for Analyte items where "RNA" is in molecule and non-RNA analytes cannot have a value for `rna_integrity_number`
 
 
 1.8.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ smaht-submitr
 Change Log
 ----------
 
+1.8.0
+=====
+`PR 27 SN Add RIN required validator <https://github.com/smaht-dac/submitr/pull/27>`_
+
+* Add a validator that ensures that the property rna_integrity_number has a value for Analyte items where "RNA" is in molecule
+
+
 1.7.2
 =====
 `WF resume_uploads credentials check <https://github.com/smaht-dac/submitr/pull/26>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smaht-submitr"
-version = "1.7.2"
+version = "1.8.0"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["SMaHT DAC <smhelp@hms-dbmi.atlassian.net >"]

--- a/submitr/validators/__init__.py
+++ b/submitr/validators/__init__.py
@@ -4,3 +4,4 @@ import submitr.validators.submitted_id_validator  # noqa
 import submitr.validators.duplicate_row_validator  # noqa
 import submitr.validators.file_set_count_validator  # noqa
 import submitr.validators.paired_read_validator  # noqa
+import submitr.validators.analyte_rin_validator  # noqa

--- a/submitr/validators/analyte_rin_validator.py
+++ b/submitr/validators/analyte_rin_validator.py
@@ -1,8 +1,6 @@
 from dcicutils.structured_data import StructuredDataSet
 from submitr.validators.decorators import structured_data_validator_finish_hook
 
-import collections
-
 # Validator that reports if any Analyte items that have molecule RNA
 # do not have the `rna_integrity_number` property filled out
 _ANALYTE_SCHEMA_NAME = "Analyte"

--- a/submitr/validators/analyte_rin_validator.py
+++ b/submitr/validators/analyte_rin_validator.py
@@ -1,0 +1,29 @@
+from dcicutils.structured_data import StructuredDataSet
+from submitr.validators.decorators import structured_data_validator_finish_hook
+
+import collections
+
+# Validator that reports if any Analyte items that have molecule RNA
+# do not have the `rna_integrity_number` property filled out
+_ANALYTE_SCHEMA_NAME = "Analyte"
+_RIN_PROPERTY_NAME = "rna_integrity_number"
+_MOLECULE_PROPERTY_NAME = "molecule"
+_RNA_VALUE = "RNA"
+
+
+@structured_data_validator_finish_hook
+def _analyte_rin_validator(structured_data: StructuredDataSet, **kwargs) -> None:
+    if not isinstance(data := structured_data.data.get(_ANALYTE_SCHEMA_NAME), list):
+        return
+    for item in data:
+        if _MOLECULE_PROPERTY_NAME in item and (
+            submitted_id := item.get("submitted_id")
+        ):
+            if _RNA_VALUE in item.get(_MOLECULE_PROPERTY_NAME) and _RIN_PROPERTY_NAME not in item:
+                # rna_integrity_number not present
+                structured_data.note_validation_error(
+                    f"{_ANALYTE_SCHEMA_NAME}:"
+                    f" item {submitted_id}"
+                    f" property {_RIN_PROPERTY_NAME} is required"
+                    f" for {_RNA_VALUE} analytes."
+                )

--- a/submitr/validators/analyte_rin_validator.py
+++ b/submitr/validators/analyte_rin_validator.py
@@ -3,6 +3,7 @@ from submitr.validators.decorators import structured_data_validator_finish_hook
 
 # Validator that reports if any Analyte items that have molecule RNA
 # do not have the `rna_integrity_number` property filled out
+# and if non-RNA Analyte items have the `rna_integrity_number` filled out
 _ANALYTE_SCHEMA_NAME = "Analyte"
 _RIN_PROPERTY_NAME = "rna_integrity_number"
 _MOLECULE_PROPERTY_NAME = "molecule"
@@ -18,10 +19,18 @@ def _analyte_rin_validator(structured_data: StructuredDataSet, **kwargs) -> None
             submitted_id := item.get("submitted_id")
         ):
             if _RNA_VALUE in item.get(_MOLECULE_PROPERTY_NAME) and _RIN_PROPERTY_NAME not in item:
-                # rna_integrity_number not present
+                # rna and rna_integrity_number not present
                 structured_data.note_validation_error(
                     f"{_ANALYTE_SCHEMA_NAME}:"
                     f" item {submitted_id}"
                     f" property {_RIN_PROPERTY_NAME} is required"
                     f" for {_RNA_VALUE} analytes."
                 )
+            elif _RNA_VALUE not in item.get(_MOLECULE_PROPERTY_NAME) and _RIN_PROPERTY_NAME in item:
+                # not rna and rna_integrity_number present
+                structured_data.note_validation_error(
+                    f"{_ANALYTE_SCHEMA_NAME}:"
+                    f" item {submitted_id}"
+                    f" property {_RIN_PROPERTY_NAME} only allowed"
+                    f" for {_RNA_VALUE} analytes."
+                )   

--- a/submitr/validators/analyte_rin_validator.py
+++ b/submitr/validators/analyte_rin_validator.py
@@ -33,4 +33,4 @@ def _analyte_rin_validator(structured_data: StructuredDataSet, **kwargs) -> None
                     f" item {submitted_id}"
                     f" property {_RIN_PROPERTY_NAME} only allowed"
                     f" for {_RNA_VALUE} analytes."
-                )   
+                )


### PR DESCRIPTION
- Add a validator that ensures that the property `rna_integrity_number` has a value for Analyte items where "RNA" is in `molecule` and non-RNA analytes cannot have a value for `rna_integrity_number`
- Tested with 
[test_analyte_rin_validator.xlsx](https://github.com/user-attachments/files/20953747/test_analyte_rin_validator.xlsx)
 using the command `submit-metadata-bundle test_analyte_rin_validator.xlsx --env data --ignore-orphans --validate`
- Expected output:
```
Validation results (preliminary): ERROR

- Data errors: 3
  - ERROR: Analyte: item DAC_ANALYTE_RNA_TEST2 property rna_integrity_number is required for RNA analytes.
  - ERROR: Analyte: item DAC_ANALYTE_DNA_TEST4 property rna_integrity_number only allowed for RNA analytes.
  - ERROR: Analyte [5]: {'submitted_id': 'DAC_ANALYTE_DNA_TEST4', 'molecule': ['DNA'], 'molecule_detail': ['Total DNA'], 'rna_integrity_number': 5.0, 'rna_integrity_number_instrument': 'Agilent Bioanalyzer', 'samples': ['DAC_TISSUE-SAMPLE_SMHT040-3Q-001C2'], 'consortia': ['358aed10-9b9d-4e26-ab84-4bd162da182b'], 'submission_centers': ['9626d82e-8110-4213-ac75-0a50adf890ff']} is not valid under any of the given schemas

Exiting with preliminary validation errors.
```