### PR TITLE
SN Add ONT unaligned reads validator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,6 @@ smaht-submitr
 Change Log
 ----------
 
-
 1.11.0
 ======
 `PR 28 SN Add ONT unaligned reads validator <https://github.com/smaht-dac/submitr/pull/28>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ smaht-submitr
 Change Log
 ----------
 
+1.10.0
+=====
+`PR 28 SN Add ONT unaligned reads validator <https://github.com/smaht-dac/submitr/pull/28>`_
+
+* Adds a validator that reports if any UnalignedRead items that are from ONT sequencers are missing the `software` property, or if any linked Software items are missing ONT-specific properties
+* Also checks if `derived_from` is missing for ONT fastq files
+
+
 1.9.0
 =====
 `PR 25 SN External ID validators <https://github.com/smaht-dac/submitr/pull/25>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smaht-submitr"
-version = "1.9.0"
+version = "1.10.0"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["SMaHT DAC <smhelp@hms-dbmi.atlassian.net >"]

--- a/submitr/validators/__init__.py
+++ b/submitr/validators/__init__.py
@@ -7,3 +7,4 @@ import submitr.validators.library_prep_validator # noqa
 import submitr.validators.paired_read_validator  # noqa
 import submitr.validators.tissue_external_id_validator  # noqa
 import submitr.validators.tissue_sample_external_id_validator  # noqa
+import submitr.validators.ont_unaligned_reads_validator  # noqa

--- a/submitr/validators/ont_unaligned_reads_validator.py
+++ b/submitr/validators/ont_unaligned_reads_validator.py
@@ -44,14 +44,14 @@ def _ont_unaligned_reads_validator(structured_data: StructuredDataSet, **kwargs)
         ):
             if (file_sets := [
                     file_set_item
-                    for file_set_item in structured_data.data.get(_FILE_SET_SCHEMA_NAME)
+                    for file_set_item in structured_data.data.get(_FILE_SET_SCHEMA_NAME, [])
                     if file_set_item.get("submitted_id")
                     in item.get(_FILE_SETS_PROPERTY_NAME)
             ]):
                 for file_set in file_sets:
                     if (sequencings := [
                         sequencing_item
-                        for sequencing_item in structured_data.data.get(_SEQUENCING_SCHEMA_NAME)
+                        for sequencing_item in structured_data.data.get(_SEQUENCING_SCHEMA_NAME, [])
                         if sequencing_item.get("submitted_id")
                         in file_set.get(_SEQUENCING_PROPERTY_NAME)
                     ]):
@@ -75,7 +75,7 @@ def _ont_unaligned_reads_validator(structured_data: StructuredDataSet, **kwargs)
                                     )
                                 elif (softwares := [
                                     software_item
-                                    for software_item in structured_data.data.get(_SOFTWARE_SCHEMA_NAME)
+                                    for software_item in structured_data.data.get(_SOFTWARE_SCHEMA_NAME, [])
                                     if software_item.get("submitted_id")
                                     in item.get(_SOFTWARE_PROPERTY_NAME)
                                 ]):

--- a/submitr/validators/ont_unaligned_reads_validator.py
+++ b/submitr/validators/ont_unaligned_reads_validator.py
@@ -1,0 +1,92 @@
+from dcicutils.structured_data import StructuredDataSet
+from submitr.validators.decorators import structured_data_validator_finish_hook
+
+import collections
+
+# Validator that reports if any UnalignedRead items that are from ONT sequencers
+# are missing the software item, or if any linked software items are missing
+# ONT-specific properties
+# Also checks if derived_from is missing for ONT fastq files
+_UNALIGNED_READS_SCHEMA_NAME = "UnalignedReads"
+_FILE_SETS_PROPERTY_NAME = "file_sets"
+_FILE_FORMAT_PROPERTY_NAME = "file_format"
+_FILE_SET_SCHEMA_NAME = "FileSet"
+_SEQUENCING_PROPERTY_NAME = "sequencing"
+_SEQUENCING_SCHEMA_NAME = "Sequencing"
+_SEQUENCER_PROPERTY_NAME = "sequencer"
+_DERIVED_FROM_PROPERTY_NAME = "derived_from"
+_SOFTWARE_PROPERTY_NAME = "software"
+_SOFTWARE_SCHEMA_NAME = "Software"
+_GPU_PROPERTY_NAME = "gpu_architecture"
+_MODEL_PROPERTY_NAME = "model"
+_TAGS_PROPERTY_NAME = "modification_tags"
+
+_ONT_SPECIFIC_PROPERTIES = [
+    _GPU_PROPERTY_NAME,
+    _MODEL_PROPERTY_NAME,
+    _TAGS_PROPERTY_NAME
+]
+
+_ONT_SEQEUENCERS = [
+    "ont_promethion_24",
+    "ont_promethion_2_solo",
+    "ont_minion_mk1b"
+]
+_FASTQ_FILE_FORMAT = "fastq_gz"
+
+@structured_data_validator_finish_hook
+def _ont_unaligned_reads_validator(structured_data: StructuredDataSet, **kwargs) -> None:
+    if not isinstance(data := structured_data.data.get(_UNALIGNED_READS_SCHEMA_NAME), list):
+        return
+    for item in data:
+        if _FILE_SETS_PROPERTY_NAME in item and (
+            submitted_id := item.get("submitted_id")
+        ):
+            if (file_sets := [
+                    file_set_item
+                    for file_set_item in structured_data.data.get(_FILE_SET_SCHEMA_NAME)
+                    if file_set_item.get("submitted_id")
+                    in item.get(_FILE_SETS_PROPERTY_NAME)
+                ]):
+                for file_set in file_sets:
+                    if (sequencings := [
+                        sequencing_item
+                        for sequencing_item in structured_data.data.get(_SEQUENCING_SCHEMA_NAME)
+                        if sequencing_item.get("submitted_id")
+                        in file_set.get(_SEQUENCING_PROPERTY_NAME)
+                    ]):
+                        for sequencing in sequencings:
+                            if sequencing.get(_SEQUENCER_PROPERTY_NAME) in _ONT_SEQEUENCERS:
+                                # ONT unaligned reads file
+                                if _DERIVED_FROM_PROPERTY_NAME not in item and item.get(_FILE_FORMAT_PROPERTY_NAME) == _FASTQ_FILE_FORMAT:
+                                    # fastq file missing derived_from
+                                    structured_data.note_validation_error(
+                                        f"{_UNALIGNED_READS_SCHEMA_NAME}:"
+                                        f" item {submitted_id}"
+                                        f" property derived_from is required for ONT fastq files."
+                                    )
+                                if _SOFTWARE_PROPERTY_NAME not in item:
+                                    # missing software
+                                    structured_data.note_validation_error(
+                                        f"{_UNALIGNED_READS_SCHEMA_NAME}:"
+                                        f" item {submitted_id}"
+                                        f" property software is required for ONT files."
+                                    )
+                                elif (softwares := [
+                                    software_item
+                                    for software_item in structured_data.data.get(_SOFTWARE_SCHEMA_NAME)
+                                    if software_item.get("submitted_id")
+                                    in item.get(_SOFTWARE_PROPERTY_NAME)
+                                ]):
+                                    for software in softwares:
+                                        missing = [ prop for prop in _ONT_SPECIFIC_PROPERTIES
+                                                   if prop not in software]
+                                        if missing:
+                                            # missing ONT-specific properties
+                                            structured_data.note_validation_error(
+                                                f"{_UNALIGNED_READS_SCHEMA_NAME}:"
+                                                f" item {submitted_id}"
+                                                f" Sequencer-specific software properties not found."
+                                                f" The following Software properties are required for ONT files: "
+                                                f" {_ONT_SPECIFIC_PROPERTIES}"
+                                            )

--- a/submitr/validators/ont_unaligned_reads_validator.py
+++ b/submitr/validators/ont_unaligned_reads_validator.py
@@ -4,7 +4,8 @@ from dcicutils.structured_data import StructuredDataSet
 from submitr.validators.decorators import structured_data_validator_finish_hook
 
 
-# Validator that reports if any UnalignedRead items that are from ONT sequencers
+# Validator that reports if any UnalignedRead items that are from ONT sequencerss
+# (determined by querying the portal for ONT platform sequencers)
 # are missing the software property, or if any linked software items are missing
 # ONT-specific properties
 # Also checks if derived_from is missing for ONT fastq files
@@ -29,15 +30,15 @@ _ONT_SPECIFIC_PROPERTIES = [
 ]
 
 _FASTQ_FILE_FORMAT = "fastq_gz"
+_ONT_SEARCH_QUERY = "search/?type=Sequencer&platform=ONT&field=identifier"
 
 
 @structured_data_validator_finish_hook
 def _ont_unaligned_reads_validator(structured_data: StructuredDataSet, **kwargs) -> None:
-    search = "search/?type=Sequencer&platform=ONT"
-    sequencers = ff_utils.search_metadata(search, key=structured_data.portal.key)
-    ont_identifiers = [seq.get("identifier", "") for seq in sequencers]
     if not isinstance(data := structured_data.data.get(_UNALIGNED_READS_SCHEMA_NAME), list):
         return
+    sequencers = ff_utils.search_metadata(_ONT_SEARCH_QUERY, key=structured_data.portal.key)
+    ont_identifiers = [seq.get("identifier", "") for seq in sequencers]
     for item in data:
         if _FILE_SETS_PROPERTY_NAME in item and (
             submitted_id := item.get("submitted_id")

--- a/submitr/validators/ont_unaligned_reads_validator.py
+++ b/submitr/validators/ont_unaligned_reads_validator.py
@@ -54,7 +54,7 @@ def _ont_unaligned_reads_validator(structured_data: StructuredDataSet, **kwargs)
                         in file_set.get(_SEQUENCING_PROPERTY_NAME)
                     ]):
                         for sequencing in sequencings:
-                            if re.match(_ONT_SEQEUENCERS_PATTERN,sequencing.get(_SEQUENCER_PROPERTY_NAME)):
+                            if re.match(_ONT_SEQEUENCERS_PATTERN, sequencing.get(_SEQUENCER_PROPERTY_NAME)):
                                 # ONT unaligned reads file
                                 if item.get(_FILE_FORMAT_PROPERTY_NAME) == _FASTQ_FILE_FORMAT:
                                     if _DERIVED_FROM_PROPERTY_NAME not in item:

--- a/submitr/validators/ont_unaligned_reads_validator.py
+++ b/submitr/validators/ont_unaligned_reads_validator.py
@@ -34,8 +34,8 @@ _FASTQ_FILE_FORMAT = "fastq_gz"
 @structured_data_validator_finish_hook
 def _ont_unaligned_reads_validator(structured_data: StructuredDataSet, **kwargs) -> None:
     search = "search/?type=Sequencer&platform=ONT"
-    sequencers = ff_utils.search_metadata(search,key=structured_data.portal.key)
-    ont_identifiers = [seq.get("identifier","") for seq in sequencers]
+    sequencers = ff_utils.search_metadata(search, key=structured_data.portal.key)
+    ont_identifiers = [seq.get("identifier", "") for seq in sequencers]
     if not isinstance(data := structured_data.data.get(_UNALIGNED_READS_SCHEMA_NAME), list):
         return
     for item in data:

--- a/submitr/validators/ont_unaligned_reads_validator.py
+++ b/submitr/validators/ont_unaligned_reads_validator.py
@@ -47,7 +47,7 @@ def _ont_unaligned_reads_validator(structured_data: StructuredDataSet, **kwargs)
                     for file_set_item in structured_data.data.get(_FILE_SET_SCHEMA_NAME)
                     if file_set_item.get("submitted_id")
                     in item.get(_FILE_SETS_PROPERTY_NAME)
-                ]):
+            ]):
                 for file_set in file_sets:
                     if (sequencings := [
                         sequencing_item
@@ -80,8 +80,10 @@ def _ont_unaligned_reads_validator(structured_data: StructuredDataSet, **kwargs)
                                     in item.get(_SOFTWARE_PROPERTY_NAME)
                                 ]):
                                     for software in softwares:
-                                        missing = [prop for prop in _ONT_SPECIFIC_PROPERTIES
-                                            if prop not in software]
+                                        missing = [
+                                            prop for prop in _ONT_SPECIFIC_PROPERTIES
+                                            if prop not in software
+                                        ]
                                         if missing:
                                             # missing ONT-specific properties
                                             structured_data.note_validation_error(

--- a/submitr/validators/ont_unaligned_reads_validator.py
+++ b/submitr/validators/ont_unaligned_reads_validator.py
@@ -1,3 +1,5 @@
+import re
+
 from dcicutils.structured_data import StructuredDataSet
 from submitr.validators.decorators import structured_data_validator_finish_hook
 
@@ -26,11 +28,7 @@ _ONT_SPECIFIC_PROPERTIES = [
     _TAGS_PROPERTY_NAME
 ]
 
-_ONT_SEQEUENCERS = [
-    "ont_promethion_24",
-    "ont_promethion_2_solo",
-    "ont_minion_mk1b"
-]
+_ONT_SEQEUENCERS_PATTERN = "^ont_"
 _FASTQ_FILE_FORMAT = "fastq_gz"
 
 
@@ -56,7 +54,7 @@ def _ont_unaligned_reads_validator(structured_data: StructuredDataSet, **kwargs)
                         in file_set.get(_SEQUENCING_PROPERTY_NAME)
                     ]):
                         for sequencing in sequencings:
-                            if sequencing.get(_SEQUENCER_PROPERTY_NAME) in _ONT_SEQEUENCERS:
+                            if re.match(_ONT_SEQEUENCERS_PATTERN,sequencing.get(_SEQUENCER_PROPERTY_NAME)):
                                 # ONT unaligned reads file
                                 if item.get(_FILE_FORMAT_PROPERTY_NAME) == _FASTQ_FILE_FORMAT:
                                     if _DERIVED_FROM_PROPERTY_NAME not in item:


### PR DESCRIPTION
- Adds a validator that reports if any UnalignedRead items that are from ONT sequencers are missing the `software` property, or if any linked Software items are missing ONT-specific properties
- Also checks if `derived_from` is missing for ONT fastq files

*NOTE*: If using a Sequencer item that is on the portal but that does not have an entry in the spreadsheet, check will not run. Similarly, the ONT-specific software check will not run if using a Software item that is in the portal but not in the spreadsheet. I plan to supplement with a foursight audit check that looks for the absence of `derived_from` and `software` . The ONT-specific software properties check is already supplemented with a custom validator.

Checks were run using 
[test_ont_unaligned_reads.xlsx](https://github.com/user-attachments/files/21147432/test_ont_unaligned_reads.xlsx)
 and the command `submit-metadata-bundle --env devtest --validate test_ont_unaligned_reads.xlsx`

Expected output is:
```
Validation results (preliminary): ERROR

- Data errors: 5
  - ERROR: UnalignedReads: item DAC_UNALIGNED-READS_TEST_FASTQ_2 property derived_from is required for ONT fastq files.
  - ERROR: UnalignedReads: item DAC_UNALIGNED-READS_TEST_FASTQ_3 property software is required for ONT files.
  - ERROR: UnalignedReads: item DAC_UNALIGNED-READS_TEST_FASTQ_4 Sequencer-specific software properties not found. The following Software properties are required for ONT files:  ['gpu_architecture', 'model', 'modification_tags']
  - ERROR: UnalignedReads: item DAC_UNALIGNED-READS_TEST_BAM_2 property software is required for ONT files.
  - ERROR: UnalignedReads: item DAC_UNALIGNED-READS_TEST_BAM_3 Sequencer-specific software properties not found. The following Software properties are required for ONT files:  ['gpu_architecture', 'model', 'modification_tags']

Exiting with preliminary validation errors.
Use the --output FILE option to write errors to a file.
```