### PR TITLE
SN DSA Validator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ smaht-submitr
 Change Log
 ----------
 
+1.10.0
+=====
+`PR 29 SN DSA Validator <https://github.com/smaht-dac/submitr/pull/29>`_
+
+* Add validator for SupplementaryFile that checks that `haplotype` and `donor_specific_assembly` are present if `data_type` contains "DSA" and the `file_format` is "fa"
+
+
 1.9.0
 =====
 `PR 25 SN External ID validators <https://github.com/smaht-dac/submitr/pull/25>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smaht-submitr"
-version = "1.9.0"
+version = "1.10.0"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["SMaHT DAC <smhelp@hms-dbmi.atlassian.net >"]

--- a/submitr/validators/__init__.py
+++ b/submitr/validators/__init__.py
@@ -7,3 +7,4 @@ import submitr.validators.library_prep_validator # noqa
 import submitr.validators.paired_read_validator  # noqa
 import submitr.validators.tissue_external_id_validator  # noqa
 import submitr.validators.tissue_sample_external_id_validator  # noqa
+import submitr.validators.dsa_haplotype_validator  # noqa

--- a/submitr/validators/dsa_haplotype_validator.py
+++ b/submitr/validators/dsa_haplotype_validator.py
@@ -7,6 +7,7 @@ _SUPP_FILE_SCHEMA_NAME = "SupplementaryFile"
 _FILE_FORMAT_PROPERTY_NAME = "file_format"
 _HAPLOTYPE_PROPERTY_NAME = "haplotype"
 _DATA_TYPE_PROPERTY_NAME = "data_type"
+_DSA_PROPERTY_NAME = "donor_specific_assembly"
 
 _FASTA_FILE_FORMAT = "fa"
 _DSA_DATA_TYPE = "DSA"
@@ -19,11 +20,17 @@ def _dsa_haplotype_validator(structured_data: StructuredDataSet, **kwargs) -> No
         if _DATA_TYPE_PROPERTY_NAME in item and (
             submitted_id := item.get("submitted_id")
         ):
-            if item.get(_DATA_TYPE_PROPERTY_NAME) == _DSA_DATA_TYPE:
-                if item.get(_FILE_FORMAT_PROPERTY_NAME) == _FASTA_FILE_FORMAT:
+            if item.get(_FILE_FORMAT_PROPERTY_NAME) == _FASTA_FILE_FORMAT:
+                if _DSA_DATA_TYPE in item.get(_DATA_TYPE_PROPERTY_NAME):
                     if _HAPLOTYPE_PROPERTY_NAME not in item:
                         structured_data.note_validation_error(
                             f"{_SUPP_FILE_SCHEMA_NAME}: {submitted_id}"
                             f" property {_HAPLOTYPE_PROPERTY_NAME}"
+                            f" is required for DSA fasta files"
+                        )
+                    if _DSA_PROPERTY_NAME not in item:
+                        structured_data.note_validation_error(
+                            f"{_SUPP_FILE_SCHEMA_NAME}: {submitted_id}"
+                            f" property {_DSA_PROPERTY_NAME}"
                             f" is required for DSA fasta files"
                         )

--- a/submitr/validators/dsa_haplotype_validator.py
+++ b/submitr/validators/dsa_haplotype_validator.py
@@ -1,0 +1,29 @@
+from dcicutils.structured_data import StructuredDataSet
+from submitr.validators.decorators import structured_data_validator_finish_hook
+
+# Validator that reports any SupplementaryFile items that are DSA fasta files are missing the haplotype property
+
+_SUPP_FILE_SCHEMA_NAME = "SupplementaryFile"
+_FILE_FORMAT_PROPERTY_NAME = "file_format"
+_HAPLOTYPE_PROPERTY_NAME = "haplotype"
+_DATA_TYPE_PROPERTY_NAME = "data_type"
+
+_FASTA_FILE_FORMAT = "fa"
+_DSA_DATA_TYPE = "DSA"
+
+@structured_data_validator_finish_hook
+def _dsa_haplotype_validator(structured_data: StructuredDataSet, **kwargs) -> None:
+    if not isinstance(data := structured_data.data.get(_SUPP_FILE_SCHEMA_NAME), list):
+        return
+    for item in data:
+        if _DATA_TYPE_PROPERTY_NAME in item and (
+            submitted_id := item.get("submitted_id")
+        ):
+            if item.get(_DATA_TYPE_PROPERTY_NAME) == _DSA_DATA_TYPE:
+                if item.get(_FILE_FORMAT_PROPERTY_NAME) == _FASTA_FILE_FORMAT:
+                    if _HAPLOTYPE_PROPERTY_NAME not in item:
+                        structured_data.note_validation_error(
+                            f"{_SUPP_FILE_SCHEMA_NAME}: {submitted_id}"
+                            f" property {_HAPLOTYPE_PROPERTY_NAME}"
+                            f" is required for DSA fasta files"
+                        )

--- a/submitr/validators/dsa_haplotype_validator.py
+++ b/submitr/validators/dsa_haplotype_validator.py
@@ -12,6 +12,7 @@ _DSA_PROPERTY_NAME = "donor_specific_assembly"
 _FASTA_FILE_FORMAT = "fa"
 _DSA_DATA_TYPE = "DSA"
 
+
 @structured_data_validator_finish_hook
 def _dsa_haplotype_validator(structured_data: StructuredDataSet, **kwargs) -> None:
     if not isinstance(data := structured_data.data.get(_SUPP_FILE_SCHEMA_NAME), list):


### PR DESCRIPTION
- Add validator for SupplementaryFile that checks that `haplotype` and `donor_specific_assembly` are present if `data_type` is "DSA" and the `file_format` is "fa"

Tested with 
[test_dsa_haplotype_validator.xlsx](https://github.com/user-attachments/files/21264308/test_dsa_haplotype_validator.xlsx)
 using command `submit-metadata-bundle --env data --validate test_dsa_haplotype_validator.xlsx`

Expected output:
```
Validation results (preliminary): ERROR

- Data errors: 2
  - ERROR: SupplementaryFile: DAC_SUPPLEMENTARY-FILE_TEST_FA2 property haplotype is required for DSA fasta files
  - ERROR: SupplementaryFile: DAC_SUPPLEMENTARY-FILE_TEST_FA3 property donor_specific_assembly is required for DSA fasta files

Exiting with preliminary validation errors.
```