### PR TITLE
WF Update macOS runners

### DIFF
--- a/.github/workflows/main-binaries-release.yml
+++ b/.github/workflows/main-binaries-release.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
 
   build-macos-x86:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3

--- a/.github/workflows/main-binaries-test.yml
+++ b/.github/workflows/main-binaries-test.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
 
   test-macos-x86:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - name: Test MacOS Binary (x86)
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
 
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
-    ## runs-on: macos-13
+    ## runs-on: macos-15-intel
     # experimental end
     strategy:
       matrix:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ smaht-submitr
 Change Log
 ----------
 
+1.14.4
+======
+`PR 41 WF Update macOS runners <https://github.com/smaht-dac/submitr/pull/41>`_
+
+* Update macOS runners to `macos-15-intel` for x86 builds
+
 1.14.3
 ======
 `PR 35 SN Fix validation errors <https://github.com/smaht-dac/submitr/pull/35>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smaht-submitr"
-version = "1.14.3"
+version = "1.14.4"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["SMaHT DAC <smhelp@hms-dbmi.atlassian.net >"]


### PR DESCRIPTION
At the end of 2025, GitHub Actions [deprecated the macos-13 runner image](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) we're using to build our macos-x86 binary. Because of this, we are updating the runner image to `macos-15-intel`.