### PR TITLE
Validator updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,13 @@ smaht-submitr
 Change Log
 ----------
 
-1.14.4
+1.15.0
+======
+`PR 43 Validator updates <https://github.com/smaht-dac/submitr/pull/43>`_
+
+* Add feature to skip local validators by name
+* update to pathology report validators to allow either or for description and percentage for pathology finding validators 
+
 ======
 `PR 41 WF Update macOS runners <https://github.com/smaht-dac/submitr/pull/41>`_
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 * Add feature to skip local validators by name
 * update to pathology report validators to allow either or for description and percentage for pathology finding validators 
 
+1.14.4
 ======
 `PR 41 WF Update macOS runners <https://github.com/smaht-dac/submitr/pull/41>`_
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smaht-submitr"
-version = "1.14.4"
+version = "1.15.0"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["SMaHT DAC <smhelp@hms-dbmi.atlassian.net >"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smaht-submitr"
-version = "1.15.0"
+version = "1.14.4"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["SMaHT DAC <smhelp@hms-dbmi.atlassian.net >"]

--- a/submitr/scripts/submit_metadata_bundle.py
+++ b/submitr/scripts/submit_metadata_bundle.py
@@ -130,6 +130,9 @@ ADVANCED OPTIONS:
   Maximum umber of seconds to wait for server validation or submission.
 --debug
   Displays some debugging related output.
+--skip-validator VALIDATOR-FUNCTION-NAME
+  Skips the named client-side validator function; may be used more than once.
+  Use the internal validator function name, e.g. _analyte_rin_validator.
 --ping
   Pings the server; to test connectivity.
 --yes
@@ -230,6 +233,8 @@ def main(simulated_args_for_testing=None):
     parser.add_argument('--timeout', help="Wait timeout for server validation/submission.")
     parser.add_argument('--debug', action="store_true", help="Debug output.", default=False)
     parser.add_argument('--debug-sleep', help="Sleep on each row read for troubleshooting/testing.", default=False)
+    parser.add_argument('--skip-validator', action='append', dest='skip_validators',
+                        help=argparse.SUPPRESS, default=None)
     parser.add_argument('--ping', action="store_true", help="Ping server.", default=False)
 
     # These original/deprecated options are just for backward compatibility.
@@ -386,7 +391,8 @@ def main(simulated_args_for_testing=None):
                              output_file=args.output,
                              timeout=args.timeout,
                              debug=args.debug,
-                             debug_sleep=args.debug_sleep)
+                             debug_sleep=args.debug_sleep,
+                             skip_validators=args.skip_validators)
 
 
 def _sanity_check_submitted_file(file_name: str) -> bool:

--- a/submitr/submission.py
+++ b/submitr/submission.py
@@ -821,6 +821,7 @@ def submit_any_ingestion(
     noversion=False,
     debug=False,
     debug_sleep=None,
+    skip_validators=None,
 ):
     """
     Does the core action of submitting a metadata bundle.
@@ -1047,6 +1048,7 @@ def submit_any_ingestion(
             verbose=verbose,
             debug=debug,
             debug_sleep=debug_sleep,
+            skip_validators=skip_validators,
         )
         if validate_local_only:
             # We actually do exit from _validate_locally if validate_local_only is True.
@@ -2504,6 +2506,7 @@ def _validate_locally(
     ignore_orphans: bool = False,
     debug: bool = False,
     debug_sleep: Optional[str] = None,
+    skip_validators: Optional[List[str]] = None,
 ) -> StructuredDataSet:
 
     if json_only:
@@ -2599,7 +2602,8 @@ def _validate_locally(
         PRINT("DEBUG: Starting client validation.")
 
     validator_hook = define_structured_data_validator_hook(
-        valid_submission_centers=valid_submission_centers
+        valid_submission_centers=valid_submission_centers,
+        skip_validators=skip_validators,
     )
     validator_sheet_hook = define_structured_data_validator_sheet_hook()
     structured_data = StructuredDataSet(

--- a/submitr/submission.py
+++ b/submitr/submission.py
@@ -2605,7 +2605,7 @@ def _validate_locally(
         valid_submission_centers=valid_submission_centers,
         skip_validators=skip_validators,
     )
-    validator_sheet_hook = define_structured_data_validator_sheet_hook()
+    validator_sheet_hook = define_structured_data_validator_sheet_hook(skip_validators=skip_validators)
     structured_data = StructuredDataSet(
         None,
         portal,

--- a/submitr/tests/test_non_brain_path_report_validator.py
+++ b/submitr/tests/test_non_brain_path_report_validator.py
@@ -419,7 +419,7 @@ def test_pathologic_findings_present_yes_valid():
 
 
 def test_pathologic_findings_present_yes_missing_description():
-    """Error: present=Yes but description is missing."""
+    """No error: present=Yes, description missing but percentage provided (at least one satisfied)."""
     data = {
         SCHEMA_NAME: [
             {
@@ -436,14 +436,11 @@ def test_pathologic_findings_present_yes_missing_description():
     }
     mock_structured_data = make_structured_data_mock(data)
     _non_brain_pathology_findings_validator(mock_structured_data)
-    mock_structured_data.note_validation_error.assert_called_once()
-    error_msg = mock_structured_data.note_validation_error.call_args[0][0]
-    assert "finding_description must be provided" in error_msg
-    assert "finding_type: Necrosis" in error_msg
+    mock_structured_data.note_validation_error.assert_not_called()
 
 
 def test_pathologic_findings_present_yes_empty_description():
-    """Error: present=Yes but description is empty string."""
+    """No error: present=Yes, description empty but percentage provided (at least one satisfied)."""
     data = {
         SCHEMA_NAME: [
             {
@@ -461,14 +458,11 @@ def test_pathologic_findings_present_yes_empty_description():
     }
     mock_structured_data = make_structured_data_mock(data)
     _non_brain_pathology_findings_validator(mock_structured_data)
-    mock_structured_data.note_validation_error.assert_called_once()
-    error_msg = mock_structured_data.note_validation_error.call_args[0][0]
-    assert "finding_description must be provided" in error_msg
-    assert "finding_type: Metaplasia" in error_msg
+    mock_structured_data.note_validation_error.assert_not_called()
 
 
 def test_pathologic_findings_present_yes_whitespace_description():
-    """Error: present=Yes but description is only whitespace."""
+    """No error: present=Yes, description whitespace-only but percentage provided (at least one satisfied)."""
     data = {
         SCHEMA_NAME: [
             {
@@ -486,13 +480,11 @@ def test_pathologic_findings_present_yes_whitespace_description():
     }
     mock_structured_data = make_structured_data_mock(data)
     _non_brain_pathology_findings_validator(mock_structured_data)
-    mock_structured_data.note_validation_error.assert_called_once()
-    error_msg = mock_structured_data.note_validation_error.call_args[0][0]
-    assert "finding_description must be provided" in error_msg
+    mock_structured_data.note_validation_error.assert_not_called()
 
 
 def test_pathologic_findings_present_yes_missing_percentage():
-    """Error: present=Yes but percentage is missing."""
+    """No error: present=Yes, percentage missing but description provided (at least one satisfied)."""
     data = {
         SCHEMA_NAME: [
             {
@@ -509,14 +501,11 @@ def test_pathologic_findings_present_yes_missing_percentage():
     }
     mock_structured_data = make_structured_data_mock(data)
     _non_brain_pathology_findings_validator(mock_structured_data)
-    mock_structured_data.note_validation_error.assert_called_once()
-    error_msg = mock_structured_data.note_validation_error.call_args[0][0]
-    assert "finding_percentage must be provided" in error_msg
-    assert "finding_type: Neoplasia/Tumor/Carcinoma" in error_msg
+    mock_structured_data.note_validation_error.assert_not_called()
 
 
-def test_pathologic_findings_present_yes_multiple_errors():
-    """Multiple errors should all be reported."""
+def test_pathologic_findings_present_yes_both_missing():
+    """One combined error when both description and percentage are absent."""
     data = {
         SCHEMA_NAME: [
             {
@@ -532,7 +521,9 @@ def test_pathologic_findings_present_yes_multiple_errors():
     }
     mock_structured_data = make_structured_data_mock(data)
     _non_brain_pathology_findings_validator(mock_structured_data)
-    assert mock_structured_data.note_validation_error.call_count == 2
+    mock_structured_data.note_validation_error.assert_called_once()
+    error_msg = mock_structured_data.note_validation_error.call_args[0][0]
+    assert "at least one of finding_description or finding_percentage must be provided" in error_msg
 
 
 def test_pathologic_findings_present_no_valid():
@@ -613,7 +604,6 @@ def test_pathologic_findings_missing_finding_type():
                 "pathologic_findings": [
                     {
                         "finding_present": "Yes",
-                        "finding_description": "Something found",
                     }
                 ],
             }

--- a/submitr/tests/test_submit_metadata_bundle.py
+++ b/submitr/tests/test_submit_metadata_bundle.py
@@ -67,7 +67,8 @@ def test_submit_metadata_bundle_script(keyfile):
                             "output_file": False,
                             "timeout": None,
                             "debug": False,
-                            "debug_sleep": False
+                            "debug_sleep": False,
+                            "skip_validators": None,
                         }
                         mock_submit_any_ingestion.assert_called_with(**expect_call_args)
                     assert output == []

--- a/submitr/validators/decorators.py
+++ b/submitr/validators/decorators.py
@@ -106,6 +106,7 @@ def structured_data_validator_sheet_hook(*decorator_args, **decorator_kwargs) ->
 #
 def define_structured_data_validator_hook(**kwargs) -> Callable:
     skip = set(kwargs.pop("skip_validators", None) or [])
+
     def hook(structured_data: StructuredDataSet, schema: str,
              column: str, row: int, value: Any) -> Any:
         if ((validator := _VALIDATORS.get(column)) or

--- a/submitr/validators/decorators.py
+++ b/submitr/validators/decorators.py
@@ -105,16 +105,19 @@ def structured_data_validator_sheet_hook(*decorator_args, **decorator_kwargs) ->
 # Define the main per-column/value StructuredDataSet hook (including the "finish" hook as a property thereof).
 #
 def define_structured_data_validator_hook(**kwargs) -> Callable:
+    skip = set(kwargs.pop("skip_validators", None) or [])
     def hook(structured_data: StructuredDataSet, schema: str,
              column: str, row: int, value: Any) -> Any:
         if ((validator := _VALIDATORS.get(column)) or
             (validator := _VALIDATORS.get(f"{schema}.{column}"))):  # noqa
-            return validator(structured_data, schema, column, row, value=value, **kwargs)
+            if validator.__name__ not in skip:
+                return validator(structured_data, schema, column, row, value=value, **kwargs)
         return value
     def finish_hook(structured_data: StructuredDataSet) -> None:  # noqa
         nonlocal kwargs
         for validator in _FINISH_VALIDATORS:
-            validator(structured_data, **kwargs)
+            if validator.__name__ not in skip:
+                validator(structured_data, **kwargs)
     setattr(hook, "finish", finish_hook)
     return hook
 

--- a/submitr/validators/decorators.py
+++ b/submitr/validators/decorators.py
@@ -125,8 +125,11 @@ def define_structured_data_validator_hook(**kwargs) -> Callable:
 
 # Define the main StructuredDataSet per-sheet hook.
 #
-def define_structured_data_validator_sheet_hook() -> Callable:
+def define_structured_data_validator_sheet_hook(**kwargs) -> Callable:
+    skip = set(kwargs.pop("skip_validators", None) or [])
+
     def hook(structured_data: StructuredDataSet, schema: str, data: dict) -> None:
         if validator := _SHEET_VALIDATORS.get(schema):
-            validator(structured_data, schema, data)
+            if validator.__name__ not in skip:
+                validator(structured_data, schema, data)
     return hook

--- a/submitr/validators/non_brain_path_report_validator.py
+++ b/submitr/validators/non_brain_path_report_validator.py
@@ -146,7 +146,7 @@ def _non_brain_pathology_findings_validator(
 ) -> None:
     """
     Validates pathologic_findings conditional logic:
-    - If finding_present = "Yes": finding_description and finding_percentage must be provided
+    - If finding_present = "Yes": either finding_description or finding_percentage must be provided
     """
     if not isinstance(data := structured_data.data.get(_SCHEMA_NAME), list):
         return
@@ -166,26 +166,18 @@ def _non_brain_pathology_findings_validator(
             percentage = finding.get("finding_percentage")
 
             if present == "Yes":
-                # When present, description must exist and have a non-empty value
-                if description is None or (
+                description_missing = description is None or (
                     isinstance(description, str) and description.strip() == ""
-                ):
-                    structured_data.note_validation_error(
-                        f"{_SCHEMA_NAME}: item {submitted_id} "
-                        f"{_PATHOLOGIC_FINDINGS_PROPERTY}[{index}] "
-                        f"(finding_type: {finding_type}): "
-                        f"when finding_present is 'Yes', "
-                        f"finding_description must be provided"
-                    )
+                )
+                percentage_missing = percentage is None or percentage == ""
 
-                # When present, percentage must exist
-                if percentage is None or percentage == "":
+                if description_missing and percentage_missing:
                     structured_data.note_validation_error(
                         f"{_SCHEMA_NAME}: item {submitted_id} "
                         f"{_PATHOLOGIC_FINDINGS_PROPERTY}[{index}] "
                         f"(finding_type: {finding_type}): "
                         f"when finding_present is 'Yes', "
-                        f"finding_percentage must be provided"
+                        f"at least one of finding_description or finding_percentage must be provided"
                     )
             elif present == "No":
                 # When not present, percentage must be absent or empty


### PR DESCRIPTION
This branch has 2 updates to validators:

1. The define decorator function (see `define_structured_data_validator_hook` is updated to allow one or more named local validators to be skipped and a 'hidden' option has been added to allow a validator to be passed in with the `--skip-validators` option. 
Note: this was added as a flexible means of dealing with a specific use case of an analyte validator for rin_number if an RNA molecule that was firing for ssRNA-seq experiments.  This approach adds flexibility for future needs and is less heavyweight in checking the other aspects of the workbook structured data or the portal (as the particular item to check may have been previously submitted to determine if it is a ssRNA-seq experiment.

2. The non-brain-pathology report validator was updated to require either one of percentage or description (instead of the more stringent both) for a pathology_findings embedded object with is_present = Yes.