### PR TITLE
Add VCF upload preflight validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@ applied per-file via `pytestmark` (see `submitr/tests/integration/`), and `pytes
 AWS auth for CI is GitHub OIDC (`aws-actions/configure-aws-credentials`) in every workflow. **Do not
 reintroduce long-lived AWS access keys.**
 
+VCF content preflight lives in `submitr/file_preflight/` and is gated from the
+`FilesForUpload.review()` seam; its structural/advisory behavior is covered by
+`submitr/tests/test_vcf_preflight.py`.
+
 Part of what the rclone tests exercise is minting scoped, short-lived credentials for one
 bucket/key, mirroring how smaht-portal issues upload credentials
 (`encoded_core.types.file.external_creds`). **`sts:GetFederationToken` cannot be used for that under

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ smaht-submitr
 Change Log
 ----------
 
+1.17.0
+======
+
+* Add a pure-Python VCF preflight that checks compressed-stream integrity,
+  required VCF header shape, and record shape before upload. Structural
+  failures block upload; narrowly scoped header compatibility findings require
+  explicit confirmation.
+
 1.16.0
 ======
 `PR 44 ExternalQualityMetric ingestion <https://github.com/smaht-dac/submitr/pull/44>`_
@@ -485,4 +493,3 @@ Thug commit changing beta dcicutils to real one (8.18.2).
 =====
 
 * Forked from SubmitCGAP 4.1.0.
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -101,6 +101,7 @@ Below (and to the left) is the general table of contents for this documentation.
 
   usage
   uploading_files
+  vcf_preflight
   advanced_usage
 
 ..  Commented out (2023-03-04) from below toctree: Decided do not really need this as this is live on portal.

--- a/docs/source/vcf_preflight.rst
+++ b/docs/source/vcf_preflight.rst
@@ -18,5 +18,10 @@ Metadata-like lines with one ``#`` instead of ``##``, INFO attributes written
 with ``key: value`` instead of ``key=value``, and continuation lines without a
 key are accepted but require explicit submitter confirmation before upload.
 Line-ending and unknown-minor-version advisories use the same confirmation
-path. No reference genome is consulted and the validator does not attempt
-downstream VCF semantic or annotation validation.
+path. Normal review output aggregates repeated advisories into actionable
+counts; ``--verbose`` includes the affected line details. Review-only/
+``--validate`` output does not select a file for upload and states when that
+file would require confirmation. Structural errors are reported separately,
+take precedence, and cannot be overridden by confirmation. No reference genome
+is consulted and the validator does not attempt downstream VCF semantic or
+annotation validation.

--- a/docs/source/vcf_preflight.rst
+++ b/docs/source/vcf_preflight.rst
@@ -1,0 +1,22 @@
+VCF file preflight
+==================
+
+Submitr preflights local VCF files during the normal file review, before the
+upload confirmation. Files named ``.vcf`` or ``.vcf.gz`` and files identified
+as ``VariantCalls`` are checked with a streaming, standard-library-only
+validator.
+
+Structural failures are non-overridable and keep the file out of the upload:
+
+* gzip or BGZF decompression errors, truncation, and the configured
+  decompressed-byte limit;
+* a missing or malformed ``##fileformat`` or ``#CHROM`` header; and
+* malformed record field counts or the supported record-shape checks.
+
+The preflight also reports narrowly scoped header compatibility advisories.
+Metadata-like lines with one ``#`` instead of ``##``, INFO attributes written
+with ``key: value`` instead of ``key=value``, and continuation lines without a
+key are accepted but require explicit submitter confirmation before upload.
+Line-ending and unknown-minor-version advisories use the same confirmation
+path. No reference genome is consulted and the validator does not attempt
+downstream VCF semantic or annotation validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smaht-submitr"
-version = "1.16.0"
+version = "1.17.0"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["SMaHT DAC <smhelp@hms-dbmi.atlassian.net >"]

--- a/submitr/file_for_upload.py
+++ b/submitr/file_for_upload.py
@@ -7,6 +7,7 @@ from dcicutils.file_utils import compute_file_md5, get_file_size, normalize_path
 from dcicutils.function_cache_decorator import function_cache
 from dcicutils.misc_utils import format_size, normalize_string
 from dcicutils.structured_data import Portal, StructuredDataSet
+from submitr.file_preflight import VcfPreflightResult, is_vcf_filename, validate_vcf
 from submitr.output import PRINT
 from submitr.rclone import RCloneAmazon, RCloneStore
 from submitr.utils import chars
@@ -42,10 +43,14 @@ class FileForUpload:
         # {"uuid": "96f29020-7abd-4a42-b4c7-d342563b7074", "filename": "first_file.fastq"}
         # Or just a file name.
 
+        self._type = None
+        self._uuid = None
+        self._file_format = None
         if isinstance(file, dict):
             self._name = file.get("file", file.get("filename", ""))
             self._type = normalize_string(file.get("type")) or None
             self._uuid = normalize_string(file.get("uuid")) or None
+            self._file_format = normalize_string(file.get("file_format")) or None
         elif isinstance(file, pathlib.Path):
             self._name = str(file)
         elif isinstance(file, str):
@@ -119,6 +124,10 @@ class FileForUpload:
     @property
     def type(self) -> Optional[str]:
         return self._type
+
+    @property
+    def file_format(self) -> Optional[str]:
+        return self._file_format
 
     @property
     def accession(self) -> Optional[str]:
@@ -405,7 +414,7 @@ class FileForUpload:
                     printf(f"- File for upload: {self.path_local} ({format_size(self.size_local)})")
                     if destination:
                         printf(f"  AWS destination: {destination}")
-            return True
+            return self._review_vcf(review_only=review_only, printf=printf)
 
         elif self.found_cloud:
             printf(f"- File for upload from {self.cloud_store.proper_name_title} ({self.cloud_store.proper_name}):"
@@ -424,6 +433,45 @@ class FileForUpload:
                     printf(f"  - Use --directory to specify a directory where the file(s) can be found.")
             self._ignore = True
             return False
+
+    def _is_vcf(self) -> bool:
+        file_type = (self.type or "").lower().replace("_", "")
+        file_format = (self.file_format or "").lower().replace("_", "")
+        return (is_vcf_filename(self.name) or file_type == "variantcalls" or
+                file_format in {"vcf", "vcfgz", "variantcalls"})
+
+    def _review_vcf(self, review_only: bool, printf: Callable) -> bool:
+        """Run local VCF preflight after the local/cloud choice is resolved."""
+
+        if not self._is_vcf() or not self.from_local or not self.path:
+            return True
+
+        result: VcfPreflightResult = validate_vcf(self.path, filename=self.display_name)
+        if not result.ok:
+            printf(f"{chars.xmark} ERROR: VCF preflight failed for {self.display_name}")
+            for finding in result.structural_findings:
+                printf(f"  - {finding}")
+            if result.errors_truncated:
+                printf("  - Additional structural findings were omitted after the configured error limit.")
+            printf("  - Upload is blocked. Correct the file and run the upload again.")
+            self._ignore = True
+            return False
+
+        if not result.requires_confirmation:
+            return True
+
+        printf(f"WARNING: VCF header compatibility findings for {self.display_name}")
+        for finding in result.advisory_findings:
+            printf(f"  - {finding}")
+        if review_only:
+            printf("  - Upload confirmation is required when running without review-only mode.")
+            self._ignore = True
+            return False
+        if not yes_or_no("  - Continue with this file despite the VCF header warnings?"):
+            printf("  - File not selected for upload because confirmation was not given.")
+            self._ignore = True
+            return False
+        return True
 
     def __str__(self) -> str:  # for troubleshooting only
         return (

--- a/submitr/file_for_upload.py
+++ b/submitr/file_for_upload.py
@@ -17,6 +17,66 @@ from submitr.utils import chars
 # preventing upload credentials from being generated for anything but these statuss.
 _FILE_STATUS_UPLOADING = "uploading"
 _FILE_STATUSES_REQUIRED_FOR_UPLOAD = [_FILE_STATUS_UPLOADING, "to be uploaded by workflow", "upload failed"]
+_VCF_DEFAULT_FINDING_DETAILS = 5
+
+
+def _vcf_advisory_summary_lines(result: VcfPreflightResult) -> List[str]:
+    """Return concise, actionable summaries for bounded VCF advisory output."""
+
+    counts = result.advisory_counts
+    if not counts:
+        counts = {}
+        for finding in result.advisory_findings:
+            code = finding.code or finding.stage
+            counts[code] = counts.get(code, 0) + 1
+
+    summaries = []
+    for code, count in counts.items():
+        if code == "one_hash_header":
+            summaries.append(
+                f"{count} metadata-like header line{'s' if count != 1 else ''} use one #; "
+                "change them to ## for bcftools-compatible metadata."
+            )
+        elif code == "info_attribute_colon":
+            summaries.append(
+                f"{count} INFO declaration{'s' if count != 1 else ''} use key:value; "
+                "change the attributes to key=value."
+            )
+        elif code == "metadata_colon":
+            summaries.append(
+                f"{count} metadata line{'s' if count != 1 else ''} use key:value; "
+                "change them to key=value."
+            )
+        elif code == "keyless_continuation":
+            summaries.append(
+                f"{count} header continuation line{'s' if count != 1 else ''} have no key; "
+                "add a metadata key=value declaration."
+            )
+        elif code == "line_terminator":
+            summaries.append(
+                f"{count} line{'s' if count != 1 else ''} use non-LF terminators; "
+                "save the file with LF line endings."
+            )
+        elif code == "version":
+            summaries.append(
+                f"{count} VCF version advisory{'ies' if count != 1 else ''}; "
+                "confirm that downstream tools support the declared version."
+            )
+        else:
+            summaries.append(f"{count} header compatibility finding{'s' if count != 1 else ''} detected.")
+    return summaries
+
+
+def _print_vcf_finding_details(findings: List, *, verbose: bool, printf: Callable,
+                               kind: str) -> None:
+    """Print bounded normal-mode details or all retained verbose-mode details."""
+
+    displayed_findings = findings if verbose else findings[:_VCF_DEFAULT_FINDING_DETAILS]
+    for finding in displayed_findings:
+        printf(f"  - {finding}")
+    omitted = len(findings) - len(displayed_findings)
+    if omitted:
+        printf(f"  - {omitted} additional {kind} details omitted; rerun with --verbose for details.")
 
 
 # Unified the logic for looking for files to upload (to AWS S3), and storing
@@ -414,7 +474,7 @@ class FileForUpload:
                     printf(f"- File for upload: {self.path_local} ({format_size(self.size_local)})")
                     if destination:
                         printf(f"  AWS destination: {destination}")
-            return self._review_vcf(review_only=review_only, printf=printf)
+            return self._review_vcf(review_only=review_only, verbose=verbose, printf=printf)
 
         elif self.found_cloud:
             printf(f"- File for upload from {self.cloud_store.proper_name_title} ({self.cloud_store.proper_name}):"
@@ -440,7 +500,7 @@ class FileForUpload:
         return (is_vcf_filename(self.name) or file_type == "variantcalls" or
                 file_format in {"vcf", "vcfgz", "variantcalls"})
 
-    def _review_vcf(self, review_only: bool, printf: Callable) -> bool:
+    def _review_vcf(self, review_only: bool, verbose: bool, printf: Callable) -> bool:
         """Run local VCF preflight after the local/cloud choice is resolved."""
 
         if not self._is_vcf() or not self.from_local or not self.path:
@@ -448,11 +508,30 @@ class FileForUpload:
 
         result: VcfPreflightResult = validate_vcf(self.path, filename=self.display_name)
         if not result.ok:
-            printf(f"{chars.xmark} ERROR: VCF preflight failed for {self.display_name}")
-            for finding in result.structural_findings:
-                printf(f"  - {finding}")
+            printf(f"{chars.xmark} ERROR: VCF preflight found blocking structural errors for {self.display_name}")
+            printf("  - Structural errors block upload; confirmation cannot override them.")
+            _print_vcf_finding_details(
+                result.structural_findings,
+                verbose=verbose,
+                printf=printf,
+                kind="structural finding",
+            )
             if result.errors_truncated:
                 printf("  - Additional structural findings were omitted after the configured error limit.")
+            if result.advisory_findings:
+                advisory_count = sum(result.advisory_counts.values())
+                printf(
+                    f"  - Header compatibility findings were also detected ({advisory_count} total);"
+                    " confirmation was not requested because structural errors already block upload."
+                )
+                for summary in _vcf_advisory_summary_lines(result):
+                    printf(f"    - {summary}")
+                if verbose:
+                    printf("  - Affected header lines:")
+                    for finding in result.advisory_findings:
+                        printf(f"    - {finding}")
+                    if result.advisory_details_truncated:
+                        printf("    - Additional header line details were omitted after the configured error limit.")
             printf("  - Upload is blocked. Correct the file and run the upload again.")
             self._ignore = True
             return False
@@ -461,10 +540,24 @@ class FileForUpload:
             return True
 
         printf(f"WARNING: VCF header compatibility findings for {self.display_name}")
-        for finding in result.advisory_findings:
-            printf(f"  - {finding}")
+        advisory_count = sum(result.advisory_counts.values())
+        printf(
+            f"  - {advisory_count} advisory finding{'s' if advisory_count != 1 else ''} detected; "
+            "explicit confirmation is required to continue with upload."
+        )
+        for summary in _vcf_advisory_summary_lines(result):
+            printf(f"  - {summary}")
+        if verbose:
+            printf("  - Affected header lines:")
+            for finding in result.advisory_findings:
+                printf(f"    - {finding}")
+            if result.advisory_details_truncated:
+                printf("    - Additional header line details were omitted after the configured error limit.")
         if review_only:
-            printf("  - Upload confirmation is required when running without review-only mode.")
+            printf(
+                "  - Review-only mode: no upload will be attempted; this file would require "
+                "explicit confirmation before upload."
+            )
             self._ignore = True
             return False
         if not yes_or_no("  - Continue with this file despite the VCF header warnings?"):

--- a/submitr/file_preflight/__init__.py
+++ b/submitr/file_preflight/__init__.py
@@ -1,0 +1,15 @@
+"""Preflight validation for uploaded file contents."""
+
+from submitr.file_preflight.vcf import (
+    VcfFinding,
+    VcfPreflightResult,
+    is_vcf_filename,
+    validate_vcf,
+)
+
+__all__ = [
+    "VcfFinding",
+    "VcfPreflightResult",
+    "is_vcf_filename",
+    "validate_vcf",
+]

--- a/submitr/file_preflight/vcf.py
+++ b/submitr/file_preflight/vcf.py
@@ -15,7 +15,7 @@ import os
 from pathlib import Path
 import re
 import zlib
-from typing import BinaryIO, Iterable, List, Optional, Tuple, Union
+from typing import BinaryIO, Dict, Iterable, List, Optional, Tuple, Union
 
 
 DEFAULT_MAX_ERRORS = 25
@@ -39,6 +39,7 @@ class VcfFinding:
     message: str
     line_number: Optional[int] = None
     severity: str = "error"
+    code: Optional[str] = None
 
     @property
     def is_error(self) -> bool:
@@ -59,6 +60,8 @@ class VcfPreflightResult:
     records_checked: int = 0
     source_name: Optional[str] = None
     errors_truncated: bool = False
+    advisory_counts: Dict[str, int] = field(default_factory=dict)
+    advisory_details_truncated: bool = False
 
     @property
     def ok(self) -> bool:
@@ -99,11 +102,19 @@ class _FindingCollector:
         else:
             self.result.errors_truncated = True
 
-    def advisory(self, stage: str, message: str, line_number: Optional[int] = None) -> None:
+    def advisory(self, stage: str, message: str, line_number: Optional[int] = None,
+                 code: Optional[str] = None) -> None:
+        finding_code = code or stage
+        self.result.advisory_counts[finding_code] = (
+            self.result.advisory_counts.get(finding_code, 0) + 1
+        )
         if len(self.result.advisory_findings) < self.max_errors:
             self.result.advisory_findings.append(
-                VcfFinding(stage=stage, message=message, line_number=line_number, severity="warning")
+                VcfFinding(stage=stage, message=message, line_number=line_number,
+                           severity="warning", code=finding_code)
             )
+        else:
+            self.result.advisory_details_truncated = True
 
 
 class _ByteLimitExceeded(Exception):
@@ -282,6 +293,7 @@ def _validate_stream(source: _CountingReader,
                 "header",
                 "non-LF line terminators are accepted but may not be compatible with downstream VCF tools",
                 line_number,
+                code="line_terminator",
             )
             warned_non_lf = True
 
@@ -317,6 +329,7 @@ def _validate_stream(source: _CountingReader,
                         f"VCF version {result.version} is not one of the commonly supported 4.x versions; "
                         "continuing with structural checks",
                         line_number,
+                        code="version",
                     )
             continue
 
@@ -351,6 +364,7 @@ def _validate_stream(source: _CountingReader,
                     "header",
                     "metadata-like header line uses one #; bcftools-compatible metadata lines use ##",
                     line_number,
+                    code="one_hash_header",
                 )
                 continue
             if line.startswith("##"):
@@ -403,12 +417,14 @@ def _validate_meta_line(line: str,
                 "header",
                 "metadata uses key:value notation; bcftools-compatible metadata uses key=value",
                 line_number,
+                code="metadata_colon",
             )
         else:
             collector.advisory(
                 "header",
                 "header continuation line has no key=value declaration; add a metadata key",
                 line_number,
+                code="keyless_continuation",
             )
         return
 
@@ -430,6 +446,7 @@ def _validate_meta_line(line: str,
                 "header",
                 f"INFO attribute {attribute_name} uses key:value notation; use key=value",
                 line_number,
+                code="info_attribute_colon",
             )
 
 

--- a/submitr/file_preflight/vcf.py
+++ b/submitr/file_preflight/vcf.py
@@ -1,0 +1,508 @@
+"""A bounded, pure-Python structural preflight for VCF files.
+
+This module intentionally covers only stream integrity, required VCF header
+shape, and record shape.  It does not inspect a reference genome or attempt
+the broader semantic checks that belong in downstream QC.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from dataclasses import dataclass, field
+import gzip
+import math
+import os
+from pathlib import Path
+import re
+import zlib
+from typing import BinaryIO, Iterable, List, Optional, Tuple, Union
+
+
+DEFAULT_MAX_ERRORS = 25
+DEFAULT_MAX_LINE_BYTES = 16 * 1024 * 1024
+DEFAULT_MAX_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024
+_READ_CHUNK_BYTES = 64 * 1024
+_MANDATORY_COLUMNS = ("#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO")
+_IUPAC_BASES = frozenset("ACGTRYSWKMBDHVN")
+_META_KEY_RE = re.compile(r"^##([A-Za-z][A-Za-z0-9_.-]*)\s*=\s*(.*)$")
+_FILEFORMAT_RE = re.compile(r"^##fileformat=VCFv4\.(\d+)$")
+_POS_RE = re.compile(r"^[1-9][0-9]*$")
+_FILTER_TOKEN_RE = re.compile(r"^[^;\s]+$")
+_SYMBOLIC_ALLELE_RE = re.compile(r"^<[A-Za-z][A-Za-z0-9_.:-]*>$")
+
+
+@dataclass(frozen=True)
+class VcfFinding:
+    """One actionable structural error or advisory warning."""
+
+    stage: str
+    message: str
+    line_number: Optional[int] = None
+    severity: str = "error"
+
+    @property
+    def is_error(self) -> bool:
+        return self.severity == "error"
+
+    def __str__(self) -> str:
+        location = f"line {self.line_number}: " if self.line_number is not None else ""
+        return f"{self.stage}: {location}{self.message}"
+
+
+@dataclass
+class VcfPreflightResult:
+    """The bounded result returned by :func:`validate_vcf`."""
+
+    structural_findings: List[VcfFinding] = field(default_factory=list)
+    advisory_findings: List[VcfFinding] = field(default_factory=list)
+    version: Optional[str] = None
+    records_checked: int = 0
+    source_name: Optional[str] = None
+    errors_truncated: bool = False
+
+    @property
+    def ok(self) -> bool:
+        """Whether the file passed the non-overridable structural checks."""
+
+        return not self.structural_findings
+
+    @property
+    def requires_confirmation(self) -> bool:
+        """Whether advisory findings require an explicit upload confirmation."""
+
+        return self.ok and bool(self.advisory_findings)
+
+    @property
+    def warnings(self) -> List[VcfFinding]:
+        """Alias useful to callers that call advisory findings warnings."""
+
+        return self.advisory_findings
+
+
+class _FindingCollector:
+
+    def __init__(self, result: VcfPreflightResult, max_errors: int) -> None:
+        self.result = result
+        self.max_errors = max_errors
+
+    @property
+    def stop(self) -> bool:
+        return len(self.result.structural_findings) >= self.max_errors
+
+    def error(self, stage: str, message: str, line_number: Optional[int] = None) -> None:
+        if len(self.result.structural_findings) < self.max_errors:
+            self.result.structural_findings.append(
+                VcfFinding(stage=stage, message=message, line_number=line_number)
+            )
+            if len(self.result.structural_findings) == self.max_errors:
+                self.result.errors_truncated = True
+        else:
+            self.result.errors_truncated = True
+
+    def advisory(self, stage: str, message: str, line_number: Optional[int] = None) -> None:
+        if len(self.result.advisory_findings) < self.max_errors:
+            self.result.advisory_findings.append(
+                VcfFinding(stage=stage, message=message, line_number=line_number, severity="warning")
+            )
+
+
+class _ByteLimitExceeded(Exception):
+
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        super().__init__(f"decompressed input exceeded {limit} bytes")
+
+
+class _LineTooLong(Exception):
+
+    def __init__(self, line_number: int, limit: int) -> None:
+        self.line_number = line_number
+        self.limit = limit
+        super().__init__(f"line exceeds the {limit}-byte preflight limit")
+
+
+class _CountingReader:
+    """Read fixed-size chunks while enforcing a decompressed-byte ceiling."""
+
+    def __init__(self, source: BinaryIO, max_bytes: Optional[int]) -> None:
+        self.source = source
+        self.max_bytes = max_bytes
+        self.bytes_read = 0
+
+    def read(self, size: int = _READ_CHUNK_BYTES) -> bytes:
+        data = self.source.read(size)
+        if not isinstance(data, bytes):
+            raise TypeError("VCF input stream must return bytes")
+        self.bytes_read += len(data)
+        if self.max_bytes is not None and self.bytes_read > self.max_bytes:
+            raise _ByteLimitExceeded(self.max_bytes)
+        return data
+
+
+def _iter_binary_lines(source: _CountingReader, max_line_bytes: int) -> Iterable[Tuple[int, bytes, bytes]]:
+    """Yield ``(line number, content, terminator)`` without universal-newline loss."""
+
+    line = bytearray()
+    line_number = 1
+    pending_cr = False
+
+    def emit(terminator: bytes) -> Tuple[int, bytes, bytes]:
+        nonlocal line_number
+        emitted = (line_number, bytes(line), terminator)
+        line.clear()
+        line_number += 1
+        return emitted
+
+    while True:
+        chunk = source.read(_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        for byte in chunk:
+            if pending_cr:
+                if byte == 10:
+                    yield emit(b"\r\n")
+                    pending_cr = False
+                    continue
+                yield emit(b"\r")
+                pending_cr = False
+            if byte == 10:
+                yield emit(b"\n")
+            elif byte == 13:
+                pending_cr = True
+            else:
+                line.append(byte)
+                if len(line) > max_line_bytes:
+                    raise _LineTooLong(line_number, max_line_bytes)
+
+    if pending_cr:
+        yield emit(b"\r")
+    elif line:
+        yield emit(b"")
+
+
+def is_vcf_filename(filename: Union[str, os.PathLike]) -> bool:
+    """Return whether a filename identifies a VCF or compressed VCF."""
+
+    return str(filename).lower().endswith((".vcf", ".vcf.gz"))
+
+
+def _looks_like_gzip(path_or_stream: Union[str, os.PathLike, BinaryIO]) -> bool:
+    if isinstance(path_or_stream, (str, os.PathLike)):
+        path = Path(path_or_stream)
+        if path.name.lower().endswith(".gz"):
+            return True
+        try:
+            with path.open("rb") as source:
+                return source.read(2) == b"\x1f\x8b"
+        except OSError:
+            return False
+    try:
+        position = path_or_stream.tell()
+        magic = path_or_stream.read(2)
+        path_or_stream.seek(position)
+        return magic == b"\x1f\x8b"
+    except (AttributeError, OSError, TypeError):
+        return False
+
+
+def validate_vcf(path_or_stream: Union[str, os.PathLike, BinaryIO],
+                 *,
+                 filename: Optional[str] = None,
+                 compressed: Optional[bool] = None,
+                 max_errors: int = DEFAULT_MAX_ERRORS,
+                 max_line_bytes: int = DEFAULT_MAX_LINE_BYTES,
+                 max_uncompressed_bytes: Optional[int] = DEFAULT_MAX_UNCOMPRESSED_BYTES) -> VcfPreflightResult:
+    """Validate a VCF path or binary stream using only the Python standard library.
+
+    Structural findings make ``result.ok`` false and are never overrideable by
+    the upload review.  Advisory findings leave ``result.ok`` true but make
+    ``result.requires_confirmation`` true.
+    """
+
+    if max_errors < 1:
+        raise ValueError("max_errors must be at least 1")
+    if max_line_bytes < 1:
+        raise ValueError("max_line_bytes must be at least 1")
+    if max_uncompressed_bytes is not None and max_uncompressed_bytes < 1:
+        raise ValueError("max_uncompressed_bytes must be at least 1 or None")
+
+    source_name = filename or str(getattr(path_or_stream, "name", "<stream>"))
+    compressed = _looks_like_gzip(path_or_stream) if compressed is None else compressed
+    result = VcfPreflightResult(source_name=source_name)
+    collector = _FindingCollector(result, max_errors=max_errors)
+
+    try:
+        with ExitStack() as stack:
+            if isinstance(path_or_stream, (str, os.PathLike)):
+                raw_source = stack.enter_context(open(path_or_stream, "rb"))
+            else:
+                raw_source = path_or_stream
+            if compressed:
+                source = stack.enter_context(gzip.GzipFile(fileobj=raw_source, mode="rb"))
+            else:
+                source = raw_source
+            _validate_stream(
+                _CountingReader(source, max_uncompressed_bytes),
+                result=result,
+                collector=collector,
+                max_line_bytes=max_line_bytes,
+            )
+    except _ByteLimitExceeded as error:
+        collector.error(
+            "compression" if compressed else "input",
+            f"decompressed input exceeds the configured {error.limit}-byte limit; "
+            "the file cannot be preflighted safely",
+        )
+    except _LineTooLong as error:
+        collector.error("record", str(error), error.line_number)
+    except (gzip.BadGzipFile, EOFError, zlib.error, OSError) as error:
+        detail = str(error) or "compressed stream ended unexpectedly"
+        collector.error(
+            "compression" if compressed else "input",
+            f"cannot read the file stream ({detail}); check for truncation or corruption",
+        )
+    return result
+
+
+def _validate_stream(source: _CountingReader,
+                     *,
+                     result: VcfPreflightResult,
+                     collector: _FindingCollector,
+                     max_line_bytes: int) -> None:
+    first_nonempty_seen = False
+    fileformat_seen = False
+    column_header_seen = False
+    column_header_line: Optional[int] = None
+    expected_fields = 0
+    warned_non_lf = False
+
+    for line_number, raw_line, terminator in _iter_binary_lines(source, max_line_bytes):
+        if terminator and terminator != b"\n" and not warned_non_lf:
+            collector.advisory(
+                "header",
+                "non-LF line terminators are accepted but may not be compatible with downstream VCF tools",
+                line_number,
+            )
+            warned_non_lf = True
+
+        try:
+            line = raw_line.decode("utf-8")
+        except UnicodeDecodeError as error:
+            collector.error(
+                "record" if column_header_seen else "header",
+                f"line is not valid UTF-8 ({error.reason}); save the VCF as UTF-8 text",
+                line_number,
+            )
+            if collector.stop:
+                break
+            continue
+
+        if not line:
+            continue
+        if not first_nonempty_seen:
+            first_nonempty_seen = True
+            fileformat_match = _FILEFORMAT_RE.fullmatch(line)
+            if not fileformat_match:
+                collector.error(
+                    "header",
+                    "first non-empty line must be ##fileformat=VCFv4.<n>",
+                    line_number,
+                )
+            else:
+                fileformat_seen = True
+                result.version = f"VCFv4.{fileformat_match.group(1)}"
+                if fileformat_match.group(1) not in {"0", "1", "2", "3"}:
+                    collector.advisory(
+                        "header",
+                        f"VCF version {result.version} is not one of the commonly supported 4.x versions; "
+                        "continuing with structural checks",
+                        line_number,
+                    )
+            continue
+
+        if not column_header_seen:
+            if line == "#CHROM" or line.startswith("#CHROM"):
+                header_fields = line.split("\t")
+                if len(header_fields) < len(_MANDATORY_COLUMNS) or tuple(header_fields[:8]) != _MANDATORY_COLUMNS:
+                    collector.error(
+                        "header",
+                        "#CHROM header must be tab-delimited and begin with "
+                        "#CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO in that order",
+                        line_number,
+                    )
+                    continue
+                if len(header_fields) == 8:
+                    expected_fields = 8
+                elif header_fields[8] != "FORMAT" or len(header_fields) < 10:
+                    collector.error(
+                        "header",
+                        "FORMAT must be followed by at least one sample column",
+                        line_number,
+                    )
+                    continue
+                else:
+                    expected_fields = len(header_fields)
+                column_header_seen = True
+                column_header_line = line_number
+                continue
+
+            if line.startswith("#") and not line.startswith("##"):
+                collector.advisory(
+                    "header",
+                    "metadata-like header line uses one #; bcftools-compatible metadata lines use ##",
+                    line_number,
+                )
+                continue
+            if line.startswith("##"):
+                _validate_meta_line(line, line_number, collector, fileformat_seen)
+                if collector.stop:
+                    break
+                continue
+            collector.error(
+                "header",
+                "expected a ## metadata line or the tab-delimited #CHROM column header",
+                line_number,
+            )
+            if collector.stop:
+                break
+            continue
+
+        if line.startswith("#"):
+            collector.error("record", "unexpected header/comment line after the #CHROM header", line_number)
+        elif line:
+            format_keys_for_record = _format_keys_for_record(line, expected_fields)
+            reasons = _record_shape_errors(line, expected_fields, format_keys_for_record)
+            if reasons:
+                collector.error("record", "; ".join(reasons), line_number)
+            else:
+                result.records_checked += 1
+        if collector.stop:
+            break
+
+    if not first_nonempty_seen:
+        collector.error("header", "file is empty; a VCF must contain a fileformat and #CHROM header")
+    elif not fileformat_seen:
+        collector.error("header", "missing required first-line ##fileformat=VCFv4.<n> metadata")
+    if not column_header_seen:
+        collector.error(
+            "header",
+            "missing required tab-delimited #CHROM column header",
+            column_header_line,
+        )
+
+
+def _validate_meta_line(line: str,
+                        line_number: int,
+                        collector: _FindingCollector,
+                        fileformat_seen: bool) -> None:
+    match = _META_KEY_RE.fullmatch(line)
+    if not match:
+        key_value_match = re.match(r"^##\s*[A-Za-z][A-Za-z0-9_.-]*\s*:", line)
+        if key_value_match:
+            collector.advisory(
+                "header",
+                "metadata uses key:value notation; bcftools-compatible metadata uses key=value",
+                line_number,
+            )
+        else:
+            collector.advisory(
+                "header",
+                "header continuation line has no key=value declaration; add a metadata key",
+                line_number,
+            )
+        return
+
+    key, value = match.groups()
+    if key == "fileformat" and fileformat_seen:
+        collector.error("header", "##fileformat appears more than once", line_number)
+        return
+    if not value.strip():
+        collector.error("header", f"##{key} metadata has an empty value", line_number)
+        return
+    if value.lstrip().startswith("<") and not value.rstrip().endswith(">"):
+        collector.error("header", f"##{key} structured metadata is missing its closing >", line_number)
+        return
+
+    if key.upper() == "INFO" and value.lstrip().startswith("<"):
+        inner = value.strip()[1:-1] if value.rstrip().endswith(">") else value.strip()[1:]
+        if attribute_name := _first_colon_attribute(inner):
+            collector.advisory(
+                "header",
+                f"INFO attribute {attribute_name} uses key:value notation; use key=value",
+                line_number,
+            )
+
+
+def _first_colon_attribute(value: str) -> Optional[str]:
+    """Find a colon separator outside quoted INFO attribute values."""
+
+    attribute_start = 0
+    in_quotes = False
+    escaped = False
+    for index, character in enumerate(value + ","):
+        if escaped:
+            escaped = False
+        elif character == "\\" and in_quotes:
+            escaped = True
+        elif character == '"':
+            in_quotes = not in_quotes
+        elif character == "," and not in_quotes:
+            attribute = value[attribute_start:index]
+            match = re.match(r"^\s*([A-Za-z][A-Za-z0-9_.-]*)\s*:", attribute)
+            if match:
+                return match.group(1)
+            attribute_start = index + 1
+    return None
+
+
+def _format_keys_for_record(line: str, expected_fields: int) -> List[str]:
+    fields = line.split("\t")
+    if len(fields) <= 8 or len(fields) < expected_fields:
+        return []
+    if fields[8] in {"", "."}:
+        return []
+    return fields[8].split(":")
+
+
+def _record_shape_errors(line: str, expected_fields: int, format_keys: List[str]) -> List[str]:
+    fields = line.split("\t")
+    reasons: List[str] = []
+    if len(fields) != expected_fields:
+        reasons.append(f"record has {len(fields)} tab-delimited fields; expected {expected_fields}")
+        return reasons
+
+    if not _POS_RE.fullmatch(fields[1]):
+        reasons.append("POS must be a positive integer")
+    if fields[5] != ".":
+        try:
+            quality = float(fields[5])
+            if not math.isfinite(quality) or quality < 0:
+                raise ValueError
+        except ValueError:
+            reasons.append("QUAL must be . or a non-negative number")
+    if fields[6] != ".":
+        filter_tokens = fields[6].split(";")
+        if not filter_tokens or any(not _FILTER_TOKEN_RE.fullmatch(token) for token in filter_tokens):
+            reasons.append("FILTER must be . or a non-empty semicolon-delimited token list")
+    if not _valid_allele(fields[3], allow_star=False):
+        reasons.append("REF must contain IUPAC bases or a symbolic allele")
+    alt_alleles = fields[4].split(",")
+    if not alt_alleles or any(not _valid_allele(allele, allow_star=True) for allele in alt_alleles):
+        reasons.append("ALT must contain IUPAC bases, symbolic alleles, or * separated by commas")
+
+    if expected_fields > 8:
+        if not format_keys or any(not key for key in format_keys):
+            reasons.append("FORMAT must contain non-empty colon-delimited keys")
+        elif any(len(sample.split(":")) > len(format_keys) for sample in fields[9:]):
+            reasons.append("sample FORMAT values contain more fields than the declared FORMAT keys")
+    return reasons
+
+
+def _valid_allele(allele: str, *, allow_star: bool) -> bool:
+    if not allele:
+        return False
+    if allow_star and allele == "*":
+        return True
+    if _SYMBOLIC_ALLELE_RE.fullmatch(allele):
+        return True
+    return all(base in _IUPAC_BASES for base in allele.upper())

--- a/submitr/tests/data/vcf/advisory_continuation.vcf
+++ b/submitr/tests/data/vcf/advisory_continuation.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.0
+##continuation without a key
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	10	.	A	C	.	.	.

--- a/submitr/tests/data/vcf/advisory_info_colon.vcf
+++ b/submitr/tests/data/vcf/advisory_info_colon.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.0
+##INFO=<ID:DP,Number:1,Type:String,Description:Depth>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	10	.	A	C	.	.	DP=4

--- a/submitr/tests/data/vcf/advisory_one_hash.vcf
+++ b/submitr/tests/data/vcf/advisory_one_hash.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.0
+#source: sanitized pipeline metadata
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	10	.	A	C	.	.	.

--- a/submitr/tests/data/vcf/captain_advisory_headers.vcf
+++ b/submitr/tests/data/vcf/captain_advisory_headers.vcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.0
+#pipeline-note: sanitized metadata
+##INFO=<ID:DP,Number:1,Type:String,Description:Depth>
+##continuation without a key
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	10	.	A	C	.	.	DP=4

--- a/submitr/tests/data/vcf/captain_valid_header.vcf
+++ b/submitr/tests/data/vcf/captain_valid_header.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.0
+##ref_fasta = sanitized/reference.fa
+##genomad_file = sanitized/annotations.vcf
+##ref_mask_bed = sanitized/mask.bed
+##pre-meta-rescue = sanitized command text
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	10	.	A	C	.	.	.

--- a/submitr/tests/data/vcf/combined_advisory_malformed.vcf
+++ b/submitr/tests/data/vcf/combined_advisory_malformed.vcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.0
+#pipeline-note: sanitized metadata
+##INFO=<ID:DP,Number:1,Type:String,Description:Depth>
+##continuation without a key
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	bad	.	A	C	.	PASS

--- a/submitr/tests/data/vcf/header_only.vcf
+++ b/submitr/tests/data/vcf/header_only.vcf
@@ -1,0 +1,2 @@
+##fileformat=VCFv4.3
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO

--- a/submitr/tests/data/vcf/malformed_record.vcf
+++ b/submitr/tests/data/vcf/malformed_record.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.2
+##source=submitr-regression
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	bad	.	A	C	.	PASS

--- a/submitr/tests/data/vcf/many_advisory_headers.vcf
+++ b/submitr/tests/data/vcf/many_advisory_headers.vcf
@@ -1,0 +1,33 @@
+##fileformat=VCFv4.0
+#pipeline-note-01: sanitized metadata
+#pipeline-note-02: sanitized metadata
+#pipeline-note-03: sanitized metadata
+#pipeline-note-04: sanitized metadata
+#pipeline-note-05: sanitized metadata
+#pipeline-note-06: sanitized metadata
+#pipeline-note-07: sanitized metadata
+#pipeline-note-08: sanitized metadata
+#pipeline-note-09: sanitized metadata
+#pipeline-note-10: sanitized metadata
+#pipeline-note-11: sanitized metadata
+#pipeline-note-12: sanitized metadata
+#pipeline-note-13: sanitized metadata
+#pipeline-note-14: sanitized metadata
+#pipeline-note-15: sanitized metadata
+#pipeline-note-16: sanitized metadata
+#pipeline-note-17: sanitized metadata
+#pipeline-note-18: sanitized metadata
+#pipeline-note-19: sanitized metadata
+#pipeline-note-20: sanitized metadata
+#pipeline-note-21: sanitized metadata
+#pipeline-note-22: sanitized metadata
+#pipeline-note-23: sanitized metadata
+#pipeline-note-24: sanitized metadata
+#pipeline-note-25: sanitized metadata
+#pipeline-note-26: sanitized metadata
+#pipeline-note-27: sanitized metadata
+#pipeline-note-28: sanitized metadata
+#pipeline-note-29: sanitized metadata
+#pipeline-note-30: sanitized metadata
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	10	.	A	C	.	.	.

--- a/submitr/tests/data/vcf/missing_column_header.vcf
+++ b/submitr/tests/data/vcf/missing_column_header.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.2
+##source=submitr-regression
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+chr1	10	.	A	C	.	PASS	DP=4

--- a/submitr/tests/data/vcf/valid_plain.vcf
+++ b/submitr/tests/data/vcf/valid_plain.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.2
+##source=submitr-regression
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	10	.	A	C,G	99	PASS	DP=8
+chr2	20	.	N	<DEL>	.	.	.
+chr3	30	.	A	*	.	PASS	.

--- a/submitr/tests/data/vcf/valid_samples.vcf
+++ b/submitr/tests/data/vcf/valid_samples.vcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.3
+##source=submitr-regression
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_a	sample_b
+chr1	10	.	A	C,G	99	PASS	DP=8	GT:DP	0/1:8	1/2:7

--- a/submitr/tests/test_vcf_preflight.py
+++ b/submitr/tests/test_vcf_preflight.py
@@ -1,0 +1,234 @@
+import gzip
+from pathlib import Path
+import struct
+import zlib
+from unittest import mock
+
+import pytest
+
+from submitr.file_for_upload import FileForUpload, FilesForUpload
+from submitr.file_preflight import validate_vcf
+
+
+VCF_FIXTURE_DIR = Path(__file__).parent / "data" / "vcf"
+
+
+def _fixture(name):
+    return VCF_FIXTURE_DIR / name
+
+
+def _bgzf(data):
+    """Make a small BGZF stream from bytes using the public block layout."""
+
+    compressed = zlib.compress(data, wbits=-15)
+    block_size = 18 + len(compressed) + 8
+    header = b"\x1f\x8b\x08\x04\x00\x00\x00\x00\x00\xff"
+    extra = b"\x06\x00BC\x02\x00" + struct.pack("<H", block_size - 1)
+    trailer = struct.pack("<II", zlib.crc32(data) & 0xffffffff, len(data))
+    eof = bytes.fromhex("1f8b08040000000000ff0600424302001b000300000000000000000000")
+    return header + extra + compressed + trailer + eof
+
+
+@pytest.mark.parametrize("fixture", ["valid_plain.vcf", "valid_samples.vcf", "captain_valid_header.vcf"])
+def test_valid_vcf_fixtures_pass(fixture):
+    result = validate_vcf(_fixture(fixture))
+
+    assert result.ok is True
+    assert result.requires_confirmation is False
+    assert not result.structural_findings
+    assert not result.advisory_findings
+    assert result.records_checked > 0
+
+
+def test_valid_gzip_and_bgzf_streams_pass(tmp_path):
+    content = _fixture("valid_plain.vcf").read_bytes()
+    gzip_path = tmp_path / "valid.vcf.gz"
+    with gzip.open(gzip_path, "wb") as compressed:
+        compressed.write(content)
+    bgzf_path = tmp_path / "valid-bgzf.vcf.gz"
+    bgzf_path.write_bytes(_bgzf(content))
+
+    assert validate_vcf(gzip_path).ok is True
+    assert validate_vcf(bgzf_path).ok is True
+
+
+@pytest.mark.parametrize("corruptor", [lambda data: data[:-5], lambda data: data[:-1] + bytes([data[-1] ^ 1])])
+def test_compressed_corruption_blocks_upload(tmp_path, corruptor):
+    content = _fixture("valid_plain.vcf").read_bytes()
+    valid_path = tmp_path / "valid.vcf.gz"
+    with gzip.open(valid_path, "wb") as compressed:
+        compressed.write(content)
+    corrupt_path = tmp_path / "corrupt.vcf.gz"
+    corrupt_path.write_bytes(corruptor(valid_path.read_bytes()))
+
+    result = validate_vcf(corrupt_path)
+
+    assert result.ok is False
+    assert any(finding.stage == "compression" for finding in result.structural_findings)
+
+
+def test_non_gzip_named_vcf_gz_blocks_upload(tmp_path):
+    path = tmp_path / "download.vcf.gz"
+    path.write_bytes(b"<html>download failed</html>\n")
+
+    result = validate_vcf(path)
+
+    assert result.ok is False
+    assert result.structural_findings[0].stage == "compression"
+    assert "gzip" in str(result.structural_findings[0]).lower()
+
+
+@pytest.mark.parametrize("fixture", ["missing_column_header.vcf", "malformed_record.vcf"])
+def test_required_schema_and_record_shape_are_structural(fixture):
+    result = validate_vcf(_fixture(fixture))
+
+    assert result.ok is False
+    assert result.structural_findings
+    assert all(finding.severity == "error" for finding in result.structural_findings)
+
+
+def test_invalid_utf8_is_reported_with_record_line_context(tmp_path):
+    path = tmp_path / "invalid-utf8.vcf"
+    path.write_bytes(_fixture("valid_plain.vcf").read_bytes().replace(b"chr3", b"chr\xff"))
+
+    result = validate_vcf(path)
+
+    assert result.ok is False
+    assert any(finding.line_number == 7 and "UTF-8" in finding.message for finding in result.structural_findings)
+
+
+def test_sample_format_values_cannot_exceed_declared_keys(tmp_path):
+    path = tmp_path / "too-many-sample-values.vcf"
+    path.write_bytes(_fixture("valid_samples.vcf").read_bytes().replace(b"0/1:8", b"0/1:8:extra"))
+
+    result = validate_vcf(path)
+
+    assert result.ok is False
+    assert "more fields" in str(result.structural_findings[0])
+
+
+def test_crlf_is_accepted_with_an_advisory(tmp_path):
+    path = tmp_path / "windows.vcf"
+    path.write_bytes(_fixture("valid_plain.vcf").read_bytes().replace(b"\n", b"\r\n"))
+
+    result = validate_vcf(path)
+
+    assert result.ok is True
+    assert result.requires_confirmation is True
+    assert any("line terminators" in finding.message for finding in result.advisory_findings)
+
+
+@pytest.mark.parametrize(
+    ("fixture", "message"),
+    [
+        ("advisory_one_hash.vcf", "one #"),
+        ("advisory_info_colon.vcf", "key:value"),
+        ("advisory_continuation.vcf", "no key"),
+    ],
+)
+def test_captain_header_advisories_are_non_blocking(fixture, message):
+    result = validate_vcf(_fixture(fixture))
+
+    assert result.ok is True
+    assert result.requires_confirmation is True
+    assert any(message in finding.message for finding in result.advisory_findings)
+
+
+def test_captain_combined_header_fixture_has_all_three_advisories():
+    result = validate_vcf(_fixture("captain_advisory_headers.vcf"))
+
+    assert result.ok is True
+    assert len(result.advisory_findings) == 3
+    assert result.requires_confirmation is True
+
+
+def test_colons_inside_quoted_info_descriptions_are_not_advisories(tmp_path):
+    path = tmp_path / "quoted-info.vcf"
+    content = _fixture("valid_plain.vcf").read_bytes().replace(
+        b'Description="Read depth"', b'Description="depth: before,depth: after"'
+    )
+    path.write_bytes(content)
+
+    result = validate_vcf(path)
+
+    assert result.ok is True
+    assert not result.advisory_findings
+
+
+def test_record_errors_are_bounded(tmp_path):
+    content = _fixture("malformed_record.vcf").read_bytes()
+    path = tmp_path / "many-errors.vcf"
+    header = content.split(b"#CHROM", 1)[0] + b"#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+    bad_record = b"chr1\tbad\t.\tA\tC\t.\tPASS\n"
+    path.write_bytes(header + bad_record * 40)
+
+    result = validate_vcf(path, max_errors=3)
+
+    assert len(result.structural_findings) == 3
+    assert result.errors_truncated is True
+
+
+def test_decompressed_byte_limit_is_structural(tmp_path):
+    path = tmp_path / "limited.vcf"
+    path.write_bytes(_fixture("valid_plain.vcf").read_bytes())
+
+    result = validate_vcf(path, max_uncompressed_bytes=10)
+
+    assert result.ok is False
+    assert result.structural_findings[0].stage == "input"
+    assert "limit" in result.structural_findings[0].message
+
+
+@pytest.mark.parametrize("answer", [True, False])
+def test_review_requires_confirmation_for_advisory_headers(tmp_path, answer):
+    source = _fixture("captain_advisory_headers.vcf")
+    path = tmp_path / source.name
+    path.write_bytes(source.read_bytes())
+    file_for_upload = FileForUpload(path.name, main_search_directory=tmp_path)
+    output = []
+
+    with mock.patch("submitr.file_for_upload.yes_or_no", return_value=answer) as confirm:
+        reviewed = FilesForUpload.review([file_for_upload], printf=output.append)
+
+    assert reviewed is answer
+    assert file_for_upload.ignore is (not answer)
+    assert confirm.call_count == 1
+    assert any("compatibility findings" in line for line in output)
+
+
+def test_review_hard_blocks_structural_vcf_without_prompt(tmp_path):
+    source = _fixture("malformed_record.vcf")
+    path = tmp_path / source.name
+    path.write_bytes(source.read_bytes())
+    file_for_upload = FileForUpload(path.name, main_search_directory=tmp_path)
+    output = []
+
+    with mock.patch("submitr.file_for_upload.yes_or_no") as confirm:
+        reviewed = FilesForUpload.review([file_for_upload], printf=output.append)
+
+    assert reviewed is False
+    assert file_for_upload.ignore is True
+    confirm.assert_not_called()
+    assert any("Upload is blocked" in line for line in output)
+
+
+def test_variant_calls_type_runs_preflight_even_without_vcf_suffix(tmp_path):
+    path = tmp_path / "calls.data"
+    path.write_bytes(_fixture("valid_plain.vcf").read_bytes())
+    file_for_upload = FileForUpload(
+        {"file": path.name, "type": "VariantCalls"},
+        main_search_directory=tmp_path,
+    )
+
+    assert file_for_upload.review(printf=lambda message: None) is True
+
+
+def test_vcf_file_format_runs_preflight_even_without_vcf_suffix(tmp_path):
+    path = tmp_path / "calls.data"
+    path.write_bytes(_fixture("valid_plain.vcf").read_bytes())
+    file_for_upload = FileForUpload(
+        {"file": path.name, "file_format": "vcf"},
+        main_search_directory=tmp_path,
+    )
+
+    assert file_for_upload.review(printf=lambda message: None) is True

--- a/submitr/tests/test_vcf_preflight.py
+++ b/submitr/tests/test_vcf_preflight.py
@@ -186,6 +186,89 @@ def test_captain_combined_header_fixture_has_all_three_advisories():
     assert result.requires_confirmation is True
 
 
+def test_combined_advisory_and_structural_findings_remain_blocking():
+    result = validate_vcf(_fixture("combined_advisory_malformed.vcf"))
+
+    assert result.ok is False
+    assert result.requires_confirmation is False
+    assert len(result.advisory_findings) == 3
+    assert sum(result.advisory_counts.values()) == 3
+    assert result.structural_findings
+
+
+def test_default_review_aggregates_many_header_advisories(tmp_path):
+    source = _fixture("many_advisory_headers.vcf")
+    path = tmp_path / source.name
+    path.write_bytes(source.read_bytes())
+    file_for_upload = FileForUpload(path.name, main_search_directory=tmp_path)
+    output = []
+
+    with mock.patch("submitr.file_for_upload.yes_or_no", return_value=True) as confirm:
+        reviewed = FilesForUpload.review([file_for_upload], printf=output.append)
+
+    assert reviewed is True
+    assert confirm.call_count == 1
+    assert any("30 advisory findings detected" in line for line in output)
+    assert any("30 metadata-like header lines use one #" in line for line in output)
+    assert not any("line 2:" in line for line in output)
+
+
+def test_verbose_review_includes_advisory_line_details(tmp_path):
+    source = _fixture("captain_advisory_headers.vcf")
+    path = tmp_path / source.name
+    path.write_bytes(source.read_bytes())
+    file_for_upload = FileForUpload(path.name, main_search_directory=tmp_path)
+    output = []
+
+    with mock.patch("submitr.file_for_upload.yes_or_no", return_value=True):
+        reviewed = FilesForUpload.review(
+            [file_for_upload], verbose=True, printf=output.append
+        )
+
+    assert reviewed is True
+    assert any("line 2:" in line and "one #" in line for line in output)
+    assert any("line 3:" in line and "key:value" in line for line in output)
+    assert any("line 4:" in line and "no key" in line for line in output)
+
+
+def test_combined_review_surfaces_advisories_without_confirmation(tmp_path):
+    source = _fixture("combined_advisory_malformed.vcf")
+    path = tmp_path / source.name
+    path.write_bytes(source.read_bytes())
+    file_for_upload = FileForUpload(path.name, main_search_directory=tmp_path)
+    output = []
+
+    with mock.patch("submitr.file_for_upload.yes_or_no") as confirm:
+        reviewed = FilesForUpload.review([file_for_upload], printf=output.append)
+
+    assert reviewed is False
+    assert file_for_upload.ignore is True
+    confirm.assert_not_called()
+    assert any("Structural errors block upload" in line for line in output)
+    assert any("Header compatibility findings were also detected (3 total)" in line for line in output)
+    assert any("confirmation was not requested" in line for line in output)
+    assert any("Upload is blocked" in line for line in output)
+
+
+def test_review_only_advisory_output_explains_confirmation_requirement(tmp_path):
+    source = _fixture("captain_advisory_headers.vcf")
+    path = tmp_path / source.name
+    path.write_bytes(source.read_bytes())
+    file_for_upload = FileForUpload(path.name, main_search_directory=tmp_path)
+    output = []
+
+    with mock.patch("submitr.file_for_upload.yes_or_no") as confirm:
+        reviewed = FilesForUpload.review(
+            [file_for_upload], review_only=True, printf=output.append
+        )
+
+    assert reviewed is False
+    assert file_for_upload.ignore is True
+    confirm.assert_not_called()
+    assert any("Review-only mode" in line for line in output)
+    assert any("would require explicit confirmation before upload" in line for line in output)
+
+
 def test_colons_inside_quoted_info_descriptions_are_not_advisories(tmp_path):
     path = tmp_path / "quoted-info.vcf"
     content = _fixture("valid_plain.vcf").read_bytes().replace(

--- a/submitr/tests/test_vcf_preflight.py
+++ b/submitr/tests/test_vcf_preflight.py
@@ -53,6 +53,49 @@ def test_valid_gzip_and_bgzf_streams_pass(tmp_path):
     assert validate_vcf(bgzf_path).ok is True
 
 
+@pytest.mark.parametrize("encoding", ["plain", "gzip", "bgzf"])
+def test_header_only_vcf_passes_all_stream_encodings(tmp_path, encoding):
+    content = _fixture("header_only.vcf").read_bytes()
+    path = tmp_path / f"header-only-{encoding}.vcf"
+    if encoding == "plain":
+        path.write_bytes(content)
+    elif encoding == "gzip":
+        path = path.with_suffix(".vcf.gz")
+        with gzip.open(path, "wb") as compressed:
+            compressed.write(content)
+    else:
+        path = path.with_suffix(".vcf.gz")
+        path.write_bytes(_bgzf(content))
+
+    result = validate_vcf(path)
+
+    assert result.ok is True
+    assert result.records_checked == 0
+    assert not result.structural_findings
+
+
+def test_empty_plain_payload_is_structural(tmp_path):
+    path = tmp_path / "empty.vcf"
+    path.write_bytes(b"")
+
+    result = validate_vcf(path)
+
+    assert result.ok is False
+    assert any("file is empty" in finding.message for finding in result.structural_findings)
+
+
+def test_truncated_empty_gzip_payload_is_structural(tmp_path):
+    path = tmp_path / "truncated-empty.vcf.gz"
+    with gzip.open(path, "wb") as compressed:
+        compressed.write(b"")
+    path.write_bytes(path.read_bytes()[:-1])
+
+    result = validate_vcf(path)
+
+    assert result.ok is False
+    assert any(finding.stage == "compression" for finding in result.structural_findings)
+
+
 @pytest.mark.parametrize("corruptor", [lambda data: data[:-5], lambda data: data[:-1] + bytes([data[-1] ^ 1])])
 def test_compressed_corruption_blocks_upload(tmp_path, corruptor):
     content = _fixture("valid_plain.vcf").read_bytes()

--- a/submitr/tests/test_vcf_preflight.py
+++ b/submitr/tests/test_vcf_preflight.py
@@ -20,7 +20,8 @@ def _fixture(name):
 def _bgzf(data):
     """Make a small BGZF stream from bytes using the public block layout."""
 
-    compressed = zlib.compress(data, wbits=-15)
+    compressor = zlib.compressobj(wbits=-15)
+    compressed = compressor.compress(data) + compressor.flush()
     block_size = 18 + len(compressed) + 8
     header = b"\x1f\x8b\x08\x04\x00\x00\x00\x00\x00\xff"
     extra = b"\x06\x00BC\x02\x00" + struct.pack("<H", block_size - 1)


### PR DESCRIPTION
## Summary

- Add a pure-standard-library streaming VCF preflight under `submitr/file_preflight/`.
- Block uploads on compressed-stream integrity, required header/schema, and malformed record-shape failures.
- Add bounded, actionable UTF-8/line-context findings and accept plain gzip and BGZF streams.
- Add narrowly scoped header compatibility advisories for one-`#` metadata lines, INFO `key:value` attributes, and keyless continuations; these require explicit confirmation.
- Integrate the gate through `FilesForUpload.review()`, add sanitized original fixtures, documentation, and version 1.17.0 changelog entry.

## Validation

- `pytest -q submitr/tests/test_vcf_preflight.py`: 24 passed on Python 3.11
- `flake8 submitr`: passed
- `python -m compileall -q submitr`: passed on Python 3.10 and 3.11
- `pip wheel --no-deps --no-build-isolation .`: passed
- Full non-integration suite: 372 passed, 2 unrelated baseline/environment failures in `test_custom_excel` and contributor-cache validation.

## Follow-up

- Reproduced the GitHub Actions Python 3.10 failure: `zlib.compress(data, wbits=-15)` raises `TypeError` because that API does not accept `wbits`.
- Replaced it with `zlib.compressobj(wbits=-15)` plus `compress()` and `flush()` in commit `e41c9145`.
- Corrected focused fixture test: 24 passed on Python 3.10 and 24 passed on Python 3.11.
- Python 3.12 raw-DEFLATE API smoke test passed; GitHub Actions CI passed on Python 3.10, 3.11, and 3.12, and integration tests passed on Python 3.11.

## Zero-record regression

- Added `header_only.vcf` and a parameterized plain/gzip/BGZF regression; each encoding asserts `ok=True` and `records_checked=0`.
- Retained separate structural checks for an empty plain payload and a truncated empty gzip payload.
- Focused suite: 29 passed on Python 3.10 and 29 passed on Python 3.11; `flake8 submitr/tests/test_vcf_preflight.py` passed.

## Reporting follow-up

- Diagnosis: `FilesForUpload.review()` accepted `verbose`, but the VCF seam dropped it; the structural-error branch also returned before reporting advisory findings.
- Default output now aggregates advisory categories into actionable counts and states the confirmation consequence; verbose output includes retained affected-line details.
- Combined advisory-plus-structural failures show both categories, keep structural errors blocking, and never prompt or imply confirmation can override the block.
- Review-only/`--validate` output explicitly states that no upload is selected and that advisory-only files would require confirmation before upload.
- Added minimized fixtures and focused coverage for concise default output, verbose details, combined findings, review-only behavior, and unchanged valid files.
- Focused suite: 34 passed on Python 3.10 and 34 passed on Python 3.11; Flake8 and compile checks passed.