### PR TITLE
feat(submission): add ProtectedDonor transform controls and TPC gating

### DIFF
--- a/submitr/scripts/submit_metadata_bundle.py
+++ b/submitr/scripts/submit_metadata_bundle.py
@@ -233,6 +233,13 @@ def main(simulated_args_for_testing=None):
     parser.add_argument('--timeout', help="Wait timeout for server validation/submission.")
     parser.add_argument('--debug', action="store_true", help="Debug output.", default=False)
     parser.add_argument('--debug-sleep', help="Sleep on each row read for troubleshooting/testing.", default=False)
+    parser.add_argument('--no-transform-protected-donor', action="store_true",
+                        help="Do not automatically transform Donor workbook sheets for ProtectedDonor ingestion.",
+                        default=False)
+    parser.add_argument('--save-transformed-workbook',
+                        help="Save the automatically transformed Donor/ProtectedDonor workbook to this .xlsx path "
+                             "for inspection. The file must not already exist.",
+                        default=None)
     parser.add_argument('--skip-validator', action='append', dest='skip_validators',
                         help=argparse.SUPPRESS, default=None)
     parser.add_argument('--ping', action="store_true", help="Ping server.", default=False)
@@ -336,6 +343,10 @@ def main(simulated_args_for_testing=None):
         else:
             args.timeout = int(args.timeout)
 
+    if args.no_transform_protected_donor and args.save_transformed_workbook:
+        PRINT("May not specify both --no-transform-protected-donor and --save-transformed-workbook.")
+        sys.exit(2)
+
     if args.info:
         if not os.path.exists(args.bundle_filename):
             PRINT(f"File does not exist: {args.bundle_filename}")
@@ -392,7 +403,9 @@ def main(simulated_args_for_testing=None):
                              timeout=args.timeout,
                              debug=args.debug,
                              debug_sleep=args.debug_sleep,
-                             skip_validators=args.skip_validators)
+                             skip_validators=args.skip_validators,
+                             transform_protected_donor=not args.no_transform_protected_donor,
+                             transformed_workbook_path=args.save_transformed_workbook)
 
 
 def _sanity_check_submitted_file(file_name: str) -> bool:

--- a/submitr/scripts/submit_metadata_bundle.py
+++ b/submitr/scripts/submit_metadata_bundle.py
@@ -127,9 +127,11 @@ ADVANCED OPTIONS:
 --noprogress
   Do not print progress of (client-side) parsing/validation output.
 --save-transformed-workbook OUTPUT-XLSX
-  Saves the automatically transformed Donor/ProtectedDonor workbook to the
-  specified .xlsx path for visual inspection. The output file must not already
-  exist. This may not be used with --no-transform-protected-donor.
+  Transformed workbooks are saved automatically by default as
+  original.xlsx -> original.transformed.xlsx. This option only overrides that
+  output path. To reuse an already transformed workbook later, pass it as the
+  input workbook together with --no-transform-protected-donor. This may not be
+  used with --no-transform-protected-donor.
 --timeout SECONDS
   Maximum umber of seconds to wait for server validation or submission.
 --debug
@@ -238,7 +240,9 @@ def main(simulated_args_for_testing=None):
     parser.add_argument('--debug', action="store_true", help="Debug output.", default=False)
     parser.add_argument('--debug-sleep', help="Sleep on each row read for troubleshooting/testing.", default=False)
     parser.add_argument('--no-transform-protected-donor', action="store_true",
-                        help="Do not automatically transform Donor workbook sheets for ProtectedDonor ingestion.",
+                        help=("Do not automatically transform Donor workbook sheets for ProtectedDonor ingestion. "
+                              "Use this when the input workbook has already been transformed and already contains "
+                              "ProtectedDonor sheets/links."),
                         default=False)
     parser.add_argument('--save-transformed-workbook', help=argparse.SUPPRESS, default=None)
     parser.add_argument('--skip-validator', action='append', dest='skip_validators',

--- a/submitr/scripts/submit_metadata_bundle.py
+++ b/submitr/scripts/submit_metadata_bundle.py
@@ -126,6 +126,10 @@ ADVANCED OPTIONS:
   and refrains from printing lengthy content to output/stdout.
 --noprogress
   Do not print progress of (client-side) parsing/validation output.
+--save-transformed-workbook OUTPUT-XLSX
+  Saves the automatically transformed Donor/ProtectedDonor workbook to the
+  specified .xlsx path for visual inspection. The output file must not already
+  exist. This may not be used with --no-transform-protected-donor.
 --timeout SECONDS
   Maximum umber of seconds to wait for server validation or submission.
 --debug
@@ -236,10 +240,7 @@ def main(simulated_args_for_testing=None):
     parser.add_argument('--no-transform-protected-donor', action="store_true",
                         help="Do not automatically transform Donor workbook sheets for ProtectedDonor ingestion.",
                         default=False)
-    parser.add_argument('--save-transformed-workbook',
-                        help="Save the automatically transformed Donor/ProtectedDonor workbook to this .xlsx path "
-                             "for inspection. The file must not already exist.",
-                        default=None)
+    parser.add_argument('--save-transformed-workbook', help=argparse.SUPPRESS, default=None)
     parser.add_argument('--skip-validator', action='append', dest='skip_validators',
                         help=argparse.SUPPRESS, default=None)
     parser.add_argument('--ping', action="store_true", help="Ping server.", default=False)

--- a/submitr/scripts/submit_metadata_bundle.py
+++ b/submitr/scripts/submit_metadata_bundle.py
@@ -126,6 +126,10 @@ ADVANCED OPTIONS:
   and refrains from printing lengthy content to output/stdout.
 --noprogress
   Do not print progress of (client-side) parsing/validation output.
+--no-transform-protected-donor
+  Do not automatically transform Donor workbook sheets for ProtectedDonor
+  ingestion. Use this when the input workbook has already been transformed
+  and already contains ProtectedDonor sheets/links.
 --save-transformed-workbook OUTPUT-XLSX
   Transformed workbooks are saved automatically by default as
   original.xlsx -> original.transformed.xlsx. This option only overrides that

--- a/submitr/submission.py
+++ b/submitr/submission.py
@@ -597,6 +597,10 @@ def _prepare_protected_donor_transform(
         else:
             PRINT("Aborting.")
             sys.exit(1)
+    PRINT("ProtectedDonor transformation will be applied.")
+    PRINT(f"Transformed workbook output path: {format_path(output_path)}")
+    PRINT("You can later reuse this transformed workbook by passing it as input with"
+          " --no-transform-protected-donor.")
     return True, output_path
 
 

--- a/submitr/submission.py
+++ b/submitr/submission.py
@@ -870,6 +870,24 @@ def _pre_transform_to_temp_json(ingestion_filename: str, structured_data) -> Opt
         return f.name
 
 
+def _pre_transform_to_temp_json_for_excel(
+    ingestion_filename: str,
+    structured_data: Optional[StructuredDataSet],
+    portal: Portal,
+) -> Optional[str]:
+    if not _is_excel_workbook(ingestion_filename):
+        return None
+    transform_source = structured_data
+    if transform_source is None:
+        transform_source = StructuredDataSet(
+            file=ingestion_filename,
+            portal=portal,
+            excel_class=CustomExcel.with_portal(portal),
+            norefs=True,
+        )
+    return _pre_transform_to_temp_json(ingestion_filename, transform_source)
+
+
 def _resolve_app_args(
     institution, project, lab, award, app, consortium, submission_center
 ):
@@ -1269,29 +1287,41 @@ def submit_any_ingestion(
 
         SHOW(f"Continuing with additional (server) validation: {portal.server}")
 
-        validation_uuid = _initiate_server_ingestion_process(
-            portal=portal,
-            ingestion_filename=remote_ingestion_filename,
-            is_server_validation=True,
-            consortia=app_args.get("consortia"),
-            submission_centers=app_args.get("submission_centers"),
-            add_submission_center=add_submission_center,
-            post_only=post_only,
-            patch_only=patch_only,
-            autoadd=autoadd,
-            merge=merge,
-            user=(
-                {
-                    "uuid": user_record.get("uuid"),
-                    "email": user_record.get("email"),
-                    "name": user_record.get("display_title"),
-                }
-                if user_record
-                else None
-            ),
-            debug=debug,
-            debug_sleep=debug_sleep,
-        )
+        validation_upload_filename = None
+        if not protected_donor_transform:
+            validation_upload_filename = _pre_transform_to_temp_json_for_excel(
+                ingestion_filename,
+                structured_data,
+                portal,
+            )
+        try:
+            validation_uuid = _initiate_server_ingestion_process(
+                portal=portal,
+                ingestion_filename=remote_ingestion_filename,
+                upload_filename=validation_upload_filename,
+                is_server_validation=True,
+                consortia=app_args.get("consortia"),
+                submission_centers=app_args.get("submission_centers"),
+                add_submission_center=add_submission_center,
+                post_only=post_only,
+                patch_only=patch_only,
+                autoadd=autoadd,
+                merge=merge,
+                user=(
+                    {
+                        "uuid": user_record.get("uuid"),
+                        "email": user_record.get("email"),
+                        "name": user_record.get("display_title"),
+                    }
+                    if user_record
+                    else None
+                ),
+                debug=debug,
+                debug_sleep=debug_sleep,
+            )
+        finally:
+            if validation_upload_filename and os.path.exists(validation_upload_filename):
+                os.unlink(validation_upload_filename)
 
         SHOW(f"Validation tracking ID: {validation_uuid}")
 
@@ -1349,36 +1379,18 @@ def submit_any_ingestion(
     if not yes_or_no("Continue on with the actual submission?"):
         sys.exit(0)
 
-    submission_uuid = _initiate_server_ingestion_process(
-        portal=portal,
-        ingestion_filename=remote_ingestion_filename,
-        is_server_validation=False,
-        validate_remote_skip=validate_remote_skip,
-        validation_ingestion_submission_object=server_validation_response,
-        consortia=app_args.get("consortia"),
-        submission_centers=app_args.get("submission_centers"),
-        add_submission_center=add_submission_center,
-        post_only=post_only,
-        patch_only=patch_only,
-        autoadd=autoadd,
-        merge=merge,
-        user=(
-            {
-                "uuid": user_record.get("uuid"),
-                "email": user_record.get("email"),
-                "name": user_record.get("display_title"),
-            }
-            if user_record
-            else None
-        ),
-        debug=debug,
-        debug_sleep=debug_sleep,
-    )
+    submission_upload_filename = None
+    if not protected_donor_transform:
+        submission_upload_filename = _pre_transform_to_temp_json_for_excel(
+            ingestion_filename,
+            structured_data,
+            portal,
+        )
     try:
         submission_uuid = _initiate_server_ingestion_process(
             portal=portal,
-            ingestion_filename=ingestion_filename,
-            upload_filename=_submission_temp_json,
+            ingestion_filename=remote_ingestion_filename,
+            upload_filename=submission_upload_filename,
             is_server_validation=False,
             validate_remote_skip=validate_remote_skip,
             validation_ingestion_submission_object=server_validation_response,
@@ -1402,8 +1414,8 @@ def submit_any_ingestion(
             debug_sleep=debug_sleep,
         )
     finally:
-        if _submission_temp_json and os.path.exists(_submission_temp_json):
-            os.unlink(_submission_temp_json)
+        if submission_upload_filename and os.path.exists(submission_upload_filename):
+            os.unlink(submission_upload_filename)
 
     SHOW(f"Submission tracking ID: {submission_uuid}")
 

--- a/submitr/submission.py
+++ b/submitr/submission.py
@@ -28,6 +28,7 @@ from dcicutils.misc_utils import (
     environ_bool,
     format_duration,
     format_size,
+    ignored,
     is_uuid,
     url_path_join,
     normalize_spaces,
@@ -1274,7 +1275,9 @@ def submit_any_ingestion(
         )
     if protected_donor_transform:
         assert protected_donor_transformed_workbook is not None
-    remote_ingestion_filename = protected_donor_transformed_workbook if protected_donor_transform else ingestion_filename
+    remote_ingestion_filename = (
+        protected_donor_transformed_workbook if protected_donor_transform else ingestion_filename
+    )
 
     # Nevermind: Too confusing for both testing and general usage
     # to have different behaviours for admin and non-admin users.

--- a/submitr/submission.py
+++ b/submitr/submission.py
@@ -822,6 +822,8 @@ def submit_any_ingestion(
     debug=False,
     debug_sleep=None,
     skip_validators=None,
+    transform_protected_donor: bool = True,
+    transformed_workbook_path: Optional[str] = None,
 ):
     """
     Does the core action of submitting a metadata bundle.
@@ -1049,6 +1051,8 @@ def submit_any_ingestion(
             debug=debug,
             debug_sleep=debug_sleep,
             skip_validators=skip_validators,
+            transform_protected_donor=transform_protected_donor,
+            transformed_workbook_path=transformed_workbook_path,
         )
         if validate_local_only:
             # We actually do exit from _validate_locally if validate_local_only is True.
@@ -2507,6 +2511,8 @@ def _validate_locally(
     debug: bool = False,
     debug_sleep: Optional[str] = None,
     skip_validators: Optional[List[str]] = None,
+    transform_protected_donor: bool = True,
+    transformed_workbook_path: Optional[str] = None,
 ) -> StructuredDataSet:
 
     if json_only:
@@ -2625,7 +2631,9 @@ def _validate_locally(
         progress=None if noprogress else define_progress_callback(debug=debug),
         validator_hook=validator_hook,
         validator_sheet_hook=validator_sheet_hook,
-        excel_class=CustomExcel,
+        excel_class=CustomExcel.with_portal(portal,
+                                            transform_protected_donor=transform_protected_donor,
+                                            transformed_workbook_path=transformed_workbook_path),
         debug_sleep=debug_sleep,
     )
     structured_data.load_file(ingestion_filename)

--- a/submitr/submission.py
+++ b/submitr/submission.py
@@ -12,7 +12,7 @@ from typing import Any, BinaryIO, Callable, Dict, List, Literal, Optional, Tuple
 
 # get_env_real_url would rely on env_utils
 # from dcicutils.env_utils import get_env_real_url
-from dcicutils.command_utils import yes_or_no
+from dcicutils.command_utils import yes_or_no, y_or_n
 from dcicutils.common import APP_CGAP, APP_FOURFRONT, APP_SMAHT, OrchestratedApp
 from dcicutils.data_readers import Excel
 from dcicutils.datetime_utils import format_datetime
@@ -500,6 +500,129 @@ def _ingestion_submission_item_url(server, uuid):
 
 # TRY_OLD_PROTOCOL = True
 DEBUG_PROTOCOL = environ_bool("DEBUG_PROTOCOL", default=False)
+TPC_SUBMISSION_CENTER_IDENTIFIER = "ndri_tpc"
+TRANSFORMED_WORKBOOK_SUFFIX = ".transformed"
+
+
+def _is_excel_workbook(file_name: Optional[str]) -> bool:
+    return isinstance(file_name, str) and is_excel_file_name(file_name)
+
+
+def _workbook_has_visible_donor_sheet(file_name: Optional[str]) -> bool:
+    if not _is_excel_workbook(file_name):
+        return False
+    try:
+        excel = Excel(file_name)
+        return any(CustomExcel.effective_sheet_name(sheet_name) == "Donor"
+                   for sheet_name in excel.sheet_names)
+    except Exception:
+        # Let normal parsing/validation report malformed workbook errors later.
+        return False
+
+
+def _default_transformed_workbook_path(file_name: str) -> str:
+    directory, basename = os.path.split(os.path.abspath(os.path.expanduser(file_name)))
+    stem, extension = os.path.splitext(basename)
+    return os.path.join(directory, f"{stem}{TRANSFORMED_WORKBOOK_SUFFIX}{extension or '.xlsx'}")
+
+
+def _resolve_submission_center_identifiers(portal: Portal, submission_centers: Optional[List[str]]) -> List[str]:
+    identifiers = []
+    for submission_center in submission_centers or []:
+        if resolved := _get_submission_center(portal, submission_center):
+            identifiers.append(resolved)
+    return identifiers
+
+
+def _is_tpc_submission_center_identifiers(identifiers: List[str]) -> bool:
+    return (len(identifiers) == 1 and
+            identifiers[0].strip().lower() == TPC_SUBMISSION_CENTER_IDENTIFIER)
+
+
+def _prepare_protected_donor_transform(
+    *,
+    portal: Portal,
+    ingestion_filename: str,
+    submission_centers: Optional[List[str]],
+    validation: bool,
+    no_query: bool,
+    transform_protected_donor: bool,
+    transformed_workbook_path: Optional[str],
+) -> Tuple[bool, Optional[str]]:
+    if not transform_protected_donor or not _is_excel_workbook(ingestion_filename):
+        return False, None
+    if not _workbook_has_visible_donor_sheet(ingestion_filename):
+        return False, None
+    identifiers = _resolve_submission_center_identifiers(portal, submission_centers)
+    is_tpc = _is_tpc_submission_center_identifiers(identifiers)
+    centers = ", ".join(identifiers) if identifiers else "unknown"
+    if not is_tpc:
+        PRINT("WARNING: Donor metadata was detected in a non-TPC submission.")
+        PRINT(f"Submission center identifier(s): {centers}")
+        PRINT("ProtectedDonor transformation is restricted to TPC / ndri_tpc submissions.")
+        PRINT("This workbook will be ingested WITHOUT ProtectedDonor transformation if you continue.")
+        if no_query:
+            PRINT("ERROR: Non-TPC Donor submissions require interactive confirmation; aborting.")
+            sys.exit(1)
+        if not yes_or_no("Continue with plain ingestion?"):
+            PRINT("Aborting.")
+            sys.exit(1)
+        return False, None
+    if no_query:
+        apply_transform = True
+    else:
+        apply_transform = y_or_n(
+            "TPC submission with Donor metadata detected. Apply ProtectedDonor workbook transformation?",
+            default=True,
+        )
+    if not apply_transform:
+        PRINT("Aborting because visible Donor metadata in a TPC submission requires ProtectedDonor transformation.")
+        sys.exit(1)
+    output_path = os.path.abspath(os.path.expanduser(
+        transformed_workbook_path or _default_transformed_workbook_path(ingestion_filename)
+    ))
+    input_path = os.path.abspath(os.path.expanduser(ingestion_filename))
+    if output_path == input_path:
+        PRINT(f"ERROR: Transformed workbook output path must differ from input workbook path: {output_path}")
+        sys.exit(1)
+    if os.path.exists(output_path):
+        if validation:
+            PRINT(f"Overwriting existing transformed workbook: {format_path(output_path)}")
+            os.remove(output_path)
+        elif no_query:
+            PRINT(f"Overwriting existing transformed workbook: {format_path(output_path)}")
+            os.remove(output_path)
+        elif y_or_n(f"Transformed workbook already exists: {format_path(output_path)}. Overwrite?",
+                    default=False):
+            os.remove(output_path)
+        else:
+            PRINT("Aborting.")
+            sys.exit(1)
+    return True, output_path
+
+
+def _ensure_protected_donor_transformed_workbook(
+    ingestion_filename: str,
+    portal: Portal,
+    transformed_workbook_path: str,
+) -> None:
+    # Loading through CustomExcel is enough here: the workbook transform and save are
+    # side effects of parsing the Excel workbook. Full validation is handled elsewhere.
+    structured_data = StructuredDataSet(
+        file=ingestion_filename,
+        portal=portal,
+        excel_class=CustomExcel.with_portal(
+            portal,
+            transform_protected_donor=True,
+            transformed_workbook_path=transformed_workbook_path,
+        ),
+        norefs=True,
+    )
+    ignored(structured_data)
+    if not os.path.exists(transformed_workbook_path):
+        PRINT("ERROR: ProtectedDonor transformation was requested but no transformed workbook was created.")
+        PRINT("Check that the visible Donor sheet has a submitted_id column and at least one data row.")
+        sys.exit(1)
 
 
 def _initiate_server_ingestion_process(
@@ -1012,10 +1135,22 @@ def submit_any_ingestion(
     else:
         valid_submission_centers = ""
 
+    protected_donor_transform, protected_donor_transformed_workbook = _prepare_protected_donor_transform(
+        portal=portal,
+        ingestion_filename=ingestion_filename,
+        submission_centers=app_args.get("submission_centers"),
+        validation=validation,
+        no_query=no_query,
+        transform_protected_donor=transform_protected_donor,
+        transformed_workbook_path=transformed_workbook_path,
+    )
+
     if not json_only:
         PRINT(
             f"Metadata file to {'validate' if validation else 'ingest'}: {format_path(ingestion_filename)}"
         )
+        if protected_donor_transform:
+            PRINT(f"ProtectedDonor transformed workbook: {format_path(protected_donor_transformed_workbook)}")
 
     if verbose:
         SHOW(f"Metadata bundle upload bucket: {metadata_bundles_bucket}")
@@ -1051,8 +1186,8 @@ def submit_any_ingestion(
             debug=debug,
             debug_sleep=debug_sleep,
             skip_validators=skip_validators,
-            transform_protected_donor=transform_protected_donor,
-            transformed_workbook_path=transformed_workbook_path,
+            transform_protected_donor=protected_donor_transform,
+            transformed_workbook_path=protected_donor_transformed_workbook,
         )
         if validate_local_only:
             # We actually do exit from _validate_locally if validate_local_only is True.
@@ -1064,6 +1199,16 @@ def submit_any_ingestion(
             f"Skipping local (client) validation (as requested via"
             f" {'--validate-remote-only' if validate_remote_only else '--validate-local-skip'})."
         )
+
+    if protected_donor_transform and structured_data is None:
+        _ensure_protected_donor_transformed_workbook(
+            ingestion_filename,
+            portal,
+            protected_donor_transformed_workbook,
+        )
+    if protected_donor_transform:
+        assert protected_donor_transformed_workbook is not None
+    remote_ingestion_filename = protected_donor_transformed_workbook if protected_donor_transform else ingestion_filename
 
     # Nevermind: Too confusing for both testing and general usage
     # to have different behaviours for admin and non-admin users.
@@ -1082,7 +1227,7 @@ def submit_any_ingestion(
 
         validation_uuid = _initiate_server_ingestion_process(
             portal=portal,
-            ingestion_filename=ingestion_filename,
+            ingestion_filename=remote_ingestion_filename,
             is_server_validation=True,
             consortia=app_args.get("consortia"),
             submission_centers=app_args.get("submission_centers"),
@@ -1142,7 +1287,7 @@ def submit_any_ingestion(
     if validation:
         do_any_uploads(
             structured_data,
-            metadata_file=ingestion_filename,
+            metadata_file=remote_ingestion_filename,
             main_search_directory=upload_folder,
             main_search_directory_recursively=subfolders,
             cloud_store=rclone_google,
@@ -1155,14 +1300,14 @@ def submit_any_ingestion(
     # Server submission.
 
     SHOW(
-        f"Ready to submit your metadata to {portal.server}: {format_path(ingestion_filename)}"
+        f"Ready to submit your metadata to {portal.server}: {format_path(remote_ingestion_filename)}"
     )
     if not yes_or_no("Continue on with the actual submission?"):
         sys.exit(0)
 
     submission_uuid = _initiate_server_ingestion_process(
         portal=portal,
-        ingestion_filename=ingestion_filename,
+        ingestion_filename=remote_ingestion_filename,
         is_server_validation=False,
         validate_remote_skip=validate_remote_skip,
         validation_ingestion_submission_object=server_validation_response,
@@ -2511,7 +2656,7 @@ def _validate_locally(
     debug: bool = False,
     debug_sleep: Optional[str] = None,
     skip_validators: Optional[List[str]] = None,
-    transform_protected_donor: bool = True,
+    transform_protected_donor: bool = False,
     transformed_workbook_path: Optional[str] = None,
 ) -> StructuredDataSet:
 
@@ -2637,6 +2782,10 @@ def _validate_locally(
         debug_sleep=debug_sleep,
     )
     structured_data.load_file(ingestion_filename)
+    if transform_protected_donor and transformed_workbook_path and not os.path.exists(transformed_workbook_path):
+        PRINT("ERROR: ProtectedDonor transformation was requested but no transformed workbook was created.")
+        PRINT("Check that the visible Donor sheet has a submitted_id column and at least one data row.")
+        sys.exit(1)
 
     if debug:
         PRINT("DEBUG: Finished client validation.")

--- a/submitr/tests/test_submit_metadata_bundle.py
+++ b/submitr/tests/test_submit_metadata_bundle.py
@@ -69,6 +69,8 @@ def test_submit_metadata_bundle_script(keyfile):
                             "debug": False,
                             "debug_sleep": False,
                             "skip_validators": None,
+                            "transform_protected_donor": expect_call_args.get("transform_protected_donor", True),
+                            "transformed_workbook_path": expect_call_args.get("transformed_workbook_path"),
                         }
                         mock_submit_any_ingestion.assert_called_with(**expect_call_args)
                     assert output == []
@@ -87,6 +89,35 @@ def test_submit_metadata_bundle_script(keyfile):
         'no_query': False,
         'subfolders': False,
     })
+    test_it(args_in=["--no-transform-protected-donor", some_file],
+            expect_exit_code=0,
+            expect_called=True,
+            expect_call_args={
+                'ingestion_filename': some_file,
+                'ingestion_type': DEFAULT_INGESTION_TYPE,
+                'env': None,
+                'server': None,
+                'validate_remote_only': False,
+                'upload_folder': None,
+                'no_query': False,
+                'subfolders': False,
+                'transform_protected_donor': False,
+            })
+    transformed_workbook = some_file + ".transformed.xlsx"
+    test_it(args_in=["--save-transformed-workbook", transformed_workbook, some_file],
+            expect_exit_code=0,
+            expect_called=True,
+            expect_call_args={
+                'ingestion_filename': some_file,
+                'ingestion_type': DEFAULT_INGESTION_TYPE,
+                'env': None,
+                'server': None,
+                'validate_remote_only': False,
+                'upload_folder': None,
+                'no_query': False,
+                'subfolders': False,
+                'transformed_workbook_path': transformed_workbook,
+            })
     expect_call_args = {
         'ingestion_filename': some_file,
         'ingestion_type': DEFAULT_INGESTION_TYPE,

--- a/submitr/utils.py
+++ b/submitr/utils.py
@@ -6,7 +6,10 @@ import io
 from json import dumps as json_dumps, loads as json_loads
 import os
 from pathlib import Path
-import pkg_resources
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="pkg_resources is deprecated as an API.*")
+    import pkg_resources
 import requests
 from signal import signal, SIGINT
 import string

--- a/submitr/validators/brain_path_report_validator.py
+++ b/submitr/validators/brain_path_report_validator.py
@@ -1,9 +1,6 @@
 from dcicutils.structured_data import StructuredDataSet
 from submitr.validators.decorators import structured_data_validator_finish_hook
 
-print(f"DEBUG: Loading brain_path_report_validator module")
-print(f"DEBUG: Decorator type: {type(structured_data_validator_finish_hook)}")
-
 # Constants
 _SCHEMA_NAME = "BrainPathologyReport"
 _BRAIN_SUBREGIONS_PROPERTY = "brain_subregions"

--- a/submitr/validators/non_brain_path_report_validator.py
+++ b/submitr/validators/non_brain_path_report_validator.py
@@ -1,9 +1,6 @@
 from dcicutils.structured_data import StructuredDataSet
 from submitr.validators.decorators import structured_data_validator_finish_hook
 
-print(f"DEBUG: Loading non_brain_path_report_validator module")
-print(f"DEBUG: Decorator type: {type(structured_data_validator_finish_hook)}")
-
 # Constants
 _SCHEMA_NAME = "NonBrainPathologyReport"
 _TARGET_TISSUES_PROPERTY = "target_tissues"


### PR DESCRIPTION
## Intent

Update ProtectedDonor help text and runtime messaging without behavior changes

## What Changed

- Added `--no-transform-protected-donor` and `--save-transformed-workbook` CLI options to `submit_metadata_bundle.py` (mutually exclusive, validated at parse time) and wired them through to `submit_any_ingestion`/`_validate_locally`.
- Reworked ProtectedDonor handling in `submission.py`: new helpers detect a visible Donor sheet in the input workbook, resolve submission-center identifiers and require a TPC (`ndri_tpc`) submission before transforming, prompt for confirmation (or auto-apply under `--no-query`, or abort for non-interactive non-TPC submissions), compute a default `<name>.transformed.xlsx` output path (overridable via `--save-transformed-workbook`), and guard against overwriting an existing transformed workbook without confirmation.
- Server validation and submission now upload the already-transformed workbook directly (`remote_ingestion_filename`) instead of rebuilding a temp-JSON pre-transform on each call; added corresponding CLI flag test cases, removed stray debug `print` statements from the brain/non-brain path report validators, and suppressed a `pkg_resources` deprecation warning in `utils.py`.

## Risk Assessment

✅ Low: The reviewed delta (0667f55b..3f911546, the only commit not yet reflected in the already-open PR #45) is a pure documentation/messaging update: revised --help text for --save-transformed-workbook and --no-transform-protected-donor, plus three additive PRINT statements placed after all early-exit branches in _prepare_protected_donor_transform, with no control-flow or data changes; verified against actual argument wiring and default-path logic, the new text accurately describes existing behavior.

## Testing

Ran the existing `submitr/tests/test_submit_metadata_bundle.py` suite (2 passed) to confirm CLI arg-parsing and the mocked submission call remain unaffected; captured the real `--help-advanced` CLI transcript to show the updated help text as an end user would see it; and manually invoked `_prepare_protected_donor_transform` against an actual Donor-sheet workbook with a mocked TPC portal to observe the three new runtime PRINT messages while asserting the return value (applied=True, expected default output path) matches pre-change behavior. All checks passed, confirming messaging-only changes with no behavior regression.

<details>
<summary>Evidence: submit-metadata-bundle --help-advanced (renders updated --save-transformed-workbook and --no-transform-protected-donor help text)</summary>

```text
('Configuration file exists at /Users/andrew2/Library/Application Support/pypoetry, reusing this directory.\n\nConsider moving TOML configuration files to /Users/andrew2/Library/Preferences/pypoetry, as support for the legacy directory will be removed in an upcoming release.',)
+--------------------------------------------------------------------------------+
| submit-metadata-bundle                                                  1.16.0 |
+--------------------------------------------------------------------------------+
| Tool to submit submission metadata and files to SMaHT Portal.                  |
| See: https://submitr.readthedocs.io/en/latest                                  |
+--------------------------------------------------------------------------------+
| USAGE: submit-metadata-bundle METADATA-FILE [--validate | --submit] OPTIONS    |
| -----                                                                          |
| METADATA-FILE: This is the path to your metatdata file.                        |
+--------------------------------------------------------------------------------+
| OPTIONS:                                                                       |
+--------------------------------------------------------------------------------+
| --env ENVIRONMENT-NAME                                                         |
|   To specify your environment name; from your ~/.smaht-keys.json file.         |
|   Alternatively, set your SMAHT_ENV environment variable.                      |
| --keys KEYS-FILE                                                               |
|   To specify an alternate credentials/keys file,                               |
|   rather than the default ~/.smaht-keys.json file.                             |
|   Alternatively, set your SMAHT_KEYS environment variable.                     |
| --validate                                                                     |
|   To ONLY validate metadata WITHOUT submitting.                                |
|   Either this or --submit is required.                                         |
| --submit                                                                       |
|   To actually submit the metadata for ingestion (validates first).             |
|   Either this or --validation is required.                                     |
| --consortium CONSORTIUM                                                        |
|   To specify your consortium.                                                  |
|   Default is to use the consortium associated with your account.               |
| --submission-center SUBMISSION-CENTER                                          |
|   To specify your submission center.                                           |
|   Default is to use the submission center associated with your account.        |
| --directory DIRECTORY                                                          |
|   To specify a directory containing the files to upload; in addition           |
|   to the default of using the directory containing the submitted file;         |
|   this directory will be searched recursively.                                 |
| --cloud-source GOOGLE-CLOUD-STORAGE-SOURCE                                     |
|   A Google Cloud Storage (GCS) bucket or bucket/sub-folder                     |
|   from where the upload file(s) should be copied.                              |
| --cloud-credentials GCS-SERVICE-ACCOUNT-FILE                                   |
|   GCS credentials to use for --rclone-google-source;                           |
|   e.g. full path to your GCP service account file.                             |
|   May be omitted if running on a GCE instance.                                 |
| --cloud-location LOCATION                                                      |
|   The Google Cloud Storage (GCS) location (aka "region").                      |
| --info                                                                         |
|   Displays ONLY info about the specified metadata file; nothing else.          |
|   Add --refs or --files to see (linkTo) references or (upload) files.          |
| --verbose                                                                      |
|   Displays more verbose output.                                                |
| --help                                                                         |
|   Displays this documentation.                                                 |
| --help-advanced                                                                |
|   Displays this plus more advanced documentation.                              |
| --doc                                                                          |
|   Opens your browser to the Web based documentation:                           |
|   https://submitr.readthedocs.io/en/latest                                     |
+--------------------------------------------------------------------------------+
| For any issues please contact SMaHT DAC: smhelp@hms-dbmi.atlassian.net         |
+--------------------------------------------------------------------------------+
| ADVANCED OPTIONS:                                                              |
+--------------------------------------------------------------------------------+
| --validate-remote-only                                                         |
|   Performs ONLY server-side (remote) validation WITHOUT submitting.            |
| --validate-local-only                                                          |
|   Performs ONLY client-side (local) validation WITHOUT submitting.             |
| --validate-local-skip                                                          |
|   Skips client-side (local) validation.                                        |
| --validate-remote-skip                                                         |
|   Skips server-side (remote) validation.                                       |
|   Only allowed for admin users.                                                |
| --noanalyze                                                                    |
|   Skips analysis of parsed metadata WRT creates/updates.                       |
| --patch-only                                                                   |
|   Perform ONLY updates (PATCHes) for submitted data.                           |
| --post-only                                                                    |
|   Perform ONLY creates (POSTs) for submitted data.                             |
| --directory-only                                                               |
|   Same as --directory but does NOT search recursively.                         |
| --add-submission-center SUBMISSION-CENTER                                      |
|   To specify an additional submission center as having access to               |
|   the ingestion submission (object). Useful when different users               |
|   will be performing submit-metadata-bundle and resume-uploads.                |
| --consortia                                                                    |
|   Displays ONLY all known consortia; nothing else.                             |
| --submission-centers                                                           |
|   Displays ONLY all known submission centers; nothing else.                    |
| --nouploads                                                                    |
|   Do not attempt to upload any files; use resume-uploads later.                |
| --json                                                                         |
|   Displays the submitted metadata as formatted JSON.                           |
| --json-only                                                                    |
|   Displays ONLY the specified metadata as formatted JSON; nothing else.        |
| --info                                                                         |
|   Displays ONLY info about the specified metadata file; nothing else.          |
| --details                                                                      |
|   Displays slightly more detailed output.                                      |
| --output OUTPUT-FILE                                                           |
|   Writes all logging output to the specified file;                             |
|   and refrains from printing lengthy content to output/stdout.                 |
| --noprogress                                                                   |
|   Do not print progress of (client-side) parsing/validation output.            |
| --save-transformed-workbook OUTPUT-XLSX                                        |
|   Transformed workbooks are saved automatically by default as                  |
|   original.xlsx -> original.transformed.xlsx. This option only overrides that  |
|   output path. To reuse an already transformed workbook later, pass it as the  |
|   input workbook together with --no-transform-protected-donor. This may not be |
|   used with --no-transform-protected-donor.                                    |
| --timeout SECONDS                                                              |
|   Maximum umber of seconds to wait for server validation or submission.        |
| --debug                                                                        |
|   Displays some debugging related output.                                      |
| --skip-validator VALIDATOR-FUNCTION-NAME                                       |
|   Skips the named client-side validator function; may be used more than once.  |
|   Use the internal validator function name, e.g. _analyte_rin_validator.       |
| --ping                                                                         |
|   Pings the server; to test connectivity.                                      |
| --yes                                                                          |
|   Automatically answer 'yes' to any confirmation questions.                    |
+--------------------------------------------------------------------------------+
| © Copyright 2020-2024 President and Fellows of Harvard College                 |
+--------------------------------------------------------------------------------+
| A more recent version of this software is available: 1.15.0                    |
+--------------------------------------------------------------------------------+
```
</details>
<details>
<summary>Evidence: submit-metadata-bundle --help (baseline help screen, unaffected by change)</summary>

```text
('Configuration file exists at /Users/andrew2/Library/Application Support/pypoetry, reusing this directory.\n\nConsider moving TOML configuration files to /Users/andrew2/Library/Preferences/pypoetry, as support for the legacy directory will be removed in an upcoming release.',)
+-----------------------------------------------------------------------------+
| submit-metadata-bundle                                               1.16.0 |
+-----------------------------------------------------------------------------+
| Tool to submit submission metadata and files to SMaHT Portal.               |
| See: https://submitr.readthedocs.io/en/latest                               |
+-----------------------------------------------------------------------------+
| USAGE: submit-metadata-bundle METADATA-FILE [--validate | --submit] OPTIONS |
| -----                                                                       |
| METADATA-FILE: This is the path to your metatdata file.                     |
+-----------------------------------------------------------------------------+
| OPTIONS:                                                                    |
+-----------------------------------------------------------------------------+
| --env ENVIRONMENT-NAME                                                      |
|   To specify your environment name; from your ~/.smaht-keys.json file.      |
|   Alternatively, set your SMAHT_ENV environment variable.                   |
| --keys KEYS-FILE                                                            |
|   To specify an alternate credentials/keys file,                            |
|   rather than the default ~/.smaht-keys.json file.                          |
|   Alternatively, set your SMAHT_KEYS environment variable.                  |
| --validate                                                                  |
|   To ONLY validate metadata WITHOUT submitting.                             |
|   Either this or --submit is required.                                      |
| --submit                                                                    |
|   To actually submit the metadata for ingestion (validates first).          |
|   Either this or --validation is required.                                  |
| --consortium CONSORTIUM                                                     |
|   To specify your consortium.                                               |
|   Default is to use the consortium associated with your account.            |
| --submission-center SUBMISSION-CENTER                                       |
|   To specify your submission center.                                        |
|   Default is to use the submission center associated with your account.     |
| --directory DIRECTORY                                                       |
|   To specify a directory containing the files to upload; in addition        |
|   to the default of using the directory containing the submitted file;      |
|   this directory will be searched recursively.                              |
| --cloud-source GOOGLE-CLOUD-STORAGE-SOURCE                                  |
|   A Google Cloud Storage (GCS) bucket or bucket/sub-folder                  |
|   from where the upload file(s) should be copied.                           |
| --cloud-credentials GCS-SERVICE-ACCOUNT-FILE                                |
|   GCS credentials to use for --rclone-google-source;                        |
|   e.g. full path to your GCP service account file.                          |
|   May be omitted if running on a GCE instance.                              |
| --cloud-location LOCATION                                                   |
|   The Google Cloud Storage (GCS) location (aka "region").                   |
| --info                                                                      |
|   Displays ONLY info about the specified metadata file; nothing else.       |
|   Add --refs or --files to see (linkTo) references or (upload) files.       |
| --verbose                                                                   |
|   Displays more verbose output.                                             |
| --help                                                                      |
|   Displays this documentation.                                              |
| --help-advanced                                                             |
|   Displays this plus more advanced documentation.                           |
| --doc                                                                       |
|   Opens your browser to the Web based documentation:                        |
|   https://submitr.readthedocs.io/en/latest                                  |
+-----------------------------------------------------------------------------+
| For any issues please contact SMaHT DAC: smhelp@hms-dbmi.atlassian.net      |
+-----------------------------------------------------------------------------+
| © Copyright 2020-2024 President and Fellows of Harvard College              |
+-----------------------------------------------------------------------------+
| A more recent version of this software is available: 1.15.0                 |
+-----------------------------------------------------------------------------+
```
</details>
<details>
<summary>Evidence: Manual run of _prepare_protected_donor_transform against a real Donor workbook, showing new runtime PRINT messaging and confirming return values/behavior unchanged</summary>

<code>ProtectedDonor transformation will be applied.&#10;Transformed workbook output path: .../my_submission.transformed.xlsx&#10;You can later reuse this transformed workbook by passing it as input with --no-transform-protected-donor.&#10;RESULT: applied=True output_path_basename=&#39;my_submission.transformed.xlsx&#39;&#10;Behavior check passed: transform applied and output path unchanged from expected default naming.</code>

```text
('Configuration file exists at /Users/andrew2/Library/Application Support/pypoetry, reusing this directory.\n\nConsider moving TOML configuration files to /Users/andrew2/Library/Preferences/pypoetry, as support for the legacy directory will be removed in an upcoming release.',)
/tmp/no-mistakes-poetry-venvs/smaht-submitr-PMlGDqdx-py3.11/lib/python3.11/site-packages/pyramid/path.py:2: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
=== Simulated end-user run: submitting a Donor workbook as a TPC submission center ===
ProtectedDonor transformation will be applied.
Transformed workbook output path: /var/folders/t8/8mk98wrj1j34nc5hhqxqdqq80000gr/T/tmpbh85g8aw/my_submission.transformed.xlsx
You can later reuse this transformed workbook by passing it as input with --no-transform-protected-donor.
=== End of runtime messaging ===
RESULT: applied=True output_path_basename='my_submission.transformed.xlsx'
Behavior check passed: transform applied and output path unchanged from expected default naming.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b1a0c0e6256317c2c8c0fa96ba765842c9324880","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"skipped"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`poetry run pytest submitr/tests/test_submit_metadata_bundle.py -m &#34;not integration&#34;` (2 passed)</code>
- <code>`python -m submitr.scripts.submit_metadata_bundle --help-advanced` manual CLI run to inspect rendered advanced help text for --save-transformed-workbook and --no-transform-protected-donor</code>
- <code>`python -m submitr.scripts.submit_metadata_bundle --help` manual CLI run (baseline help screen)</code>
- <code>Manual script driving `_prepare_protected_donor_transform` with a real openpyxl-built Donor workbook and mocked TPC Portal to capture new runtime PRINT messages and assert applied/output_path behavior is unchanged</code>
- <code>Manual diff review of `git diff 0667f55b 3f911546` confirming only help strings and new PRINT calls were added, no control-flow or return-value changes</code>

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

- ℹ️ `CHANGELOG.rst` - No CHANGELOG.rst entry or pyproject.toml version bump exists yet for the new ProtectedDonor transform feature (--no-transform-protected-donor / --save-transformed-workbook flags, automatic Donor-&gt;ProtectedDonor workbook transform). Prior similar features (e.g. PR44 EQM transform) got a version bump + CHANGELOG entry at PR-finalization time. Leaving this for the author/maintainer to add when finalizing the PR, since the target version number and entry wording are a release judgment call outside this pass&#39;s scope.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
